### PR TITLE
A few changes to keep the executable compiling on MinGW

### DIFF
--- a/externals/findsdl2-cmake/FindSDL2_mixer.cmake
+++ b/externals/findsdl2-cmake/FindSDL2_mixer.cmake
@@ -44,6 +44,7 @@
 
 find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
         HINTS
+		$ENV{SDL2_MIXER_DIR}
         ENV SDL2MIXERDIR
         ENV SDL2DIR
         PATH_SUFFIXES SDL2
@@ -61,6 +62,7 @@ endif()
 find_library(SDL2_MIXER_LIBRARY
         NAMES SDL2_mixer
         HINTS
+		$ENV{SDL2_MIXER_DIR}
         ENV SDL2MIXERDIR
         ENV SDL2DIR
         PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}

--- a/externals/findsdl2-cmake/FindSDL2_mixer.cmake
+++ b/externals/findsdl2-cmake/FindSDL2_mixer.cmake
@@ -44,7 +44,7 @@
 
 find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
         HINTS
-		$ENV{SDL2_MIXER_DIR}
+        $ENV{SDL2_MIXER_DIR}
         ENV SDL2MIXERDIR
         ENV SDL2DIR
         PATH_SUFFIXES SDL2
@@ -62,7 +62,7 @@ endif()
 find_library(SDL2_MIXER_LIBRARY
         NAMES SDL2_mixer
         HINTS
-		$ENV{SDL2_MIXER_DIR}
+        $ENV{SDL2_MIXER_DIR}
         ENV SDL2MIXERDIR
         ENV SDL2DIR
         PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}

--- a/src/Libraries/RES/Source/resfile.c
+++ b/src/Libraries/RES/Source/resfile.c
@@ -40,6 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 
 #include "res.h"
 #include "res_.h"
@@ -122,7 +123,6 @@ size_t DG_strlcat(char* dst, const char* src, size_t dstsize)
 #ifndef _WIN32
 
 #include <dirent.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 static int check_and_append_pathelem(char dirbuf[PATH_MAX], const char* elem)

--- a/src/stubs/Carbon/carbon_stubs.c
+++ b/src/stubs/Carbon/carbon_stubs.c
@@ -1,6 +1,7 @@
 #include "Carbon.h"
 
 #include <SDL.h>
+#include <stdlib.h>
 
 #include "lg.h"
 


### PR DESCRIPTION
The two #include statements help appease the fickle MinGW gods. 

I also added an improvement to the SDL2_mixer finder.