### PR TITLE
Fix crash when Shodan blocks keypad

### DIFF
--- a/src/GameSrc/mfdfunc.c
+++ b/src/GameSrc/mfdfunc.c
@@ -2315,7 +2315,7 @@ errtype draw_shodan_influence(MFD *mfd, uchar amt)
    amt = lg_min(NUM_SHODAN_MUGS -1,amt >> SHODAN_INTERVAL_SHIFT);
    draw_raw_res_bm_extract(REF_IMG_EmailMugShotBase+FIRST_SHODAN_MUG +amt,0,0);
    //extract_temp_res_bitmap(&bm, REF_IMG_EmailMugShotBase+FIRST_SHODAN_MUG +amt);
-   gr_bitmap(&bm, 0, 0);
+   //gr_bitmap(&bm, 0, 0);
 
    gr_set_font((grs_font*)ResLock(MFD_FONT));
    wrap_text(s,MFD_VIEW_WID);


### PR DESCRIPTION
Commit 9d42788 missed a line in draw_shodan_influence() when restoring
the old HUD artwork. The function tries to draw an uninitialized bitmap,
which reproducibly crashes when running in fullscreen mode.