### PR TITLE
Fix crash when Berserk drug wears off

### DIFF
--- a/src/GameSrc/drugs.c
+++ b/src/GameSrc/drugs.c
@@ -377,7 +377,6 @@ void drug_lsd_startup(void)
 void drug_lsd_wearoff()
 {
    // Return from palette shift
-   int ppall = 0;
    gr_set_pal(0,256,ppall);
 //KLC   gamma_dealfunc(QUESTVAR_GET(GAMMACOR_QVAR));
    gamma_dealfunc(gShockPrefs.doGamma);
@@ -387,7 +386,6 @@ void drug_lsd_wearoff()
 
 void drug_lsd_closedown(uchar visible)
 {
-   int ppall = 0;
    if (visible && STATUS(DRUG_LSD) > 0)
       gr_set_pal(0,256,ppall);
 }


### PR DESCRIPTION
When the Berserk drug wears off, the default palette ('ppall' from
init.c) must be restored. Instead, a locally defined null pointer is
passed, causing a segmentation fault.