### PR TITLE
Adapt full-screen automap to display resolution

### DIFF
--- a/src/GameSrc/amaploop.c
+++ b/src/GameSrc/amaploop.c
@@ -199,9 +199,9 @@ void fsmap_startup(void)
 		oAMap(MFD_FULLSCR_MAP)->flags = f;
 	
 	// Get the graphics system setup for fullscreen drawing.
-	full_map_context = fr_place_view(FR_NEWVIEW, FR_DEFCAM, offscreenDrawSurface->pixels, 
-														FR_DOUBLEB_MASK|FR_WINDOWD_MASK, 0, 0, 
-														0, 0, 640, 480);
+	full_map_context = fr_place_view(FR_NEWVIEW, FR_DEFCAM, offscreenDrawSurface->pixels,
+					 FR_DOUBLEB_MASK|FR_WINDOWD_MASK, 0, 0, 0, 0,
+					 grd_screen_canvas->bm.w, grd_screen_canvas->bm.h);
 	gr_set_canvas(FULLMAP_CANVAS);
 	gr_clear(0xff);
 	amap_pixratio_set(FIX_UNIT);

--- a/src/GameSrc/fullamap.c
+++ b/src/GameSrc/fullamap.c
@@ -35,6 +35,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern uchar amap_ms_callback(curAMap *amptr,int x,int y,short action,ubyte but);
 extern uchar amap_scroll_handler(uiEvent* ev, 	LGRegion* r, void* user_data);
 
+extern grs_screen *svga_screen;
+extern grs_screen *cit_screen;
+
 // -------------------
 //  INTERNAL PROTOTYPES
 // -------------------
@@ -104,6 +107,7 @@ void amap_start()
    HotkeyContext = AMAP_CONTEXT;
    uiSetCurrentSlab(&amap_slab);
 
+   gr_set_screen(svga_screen);
    fsmap_startup();
    uiShowMouse(NULL);
 }
@@ -116,5 +120,6 @@ void amap_exit()
 {
    fsmap_free();
    uiHideMouse(NULL);
+   gr_set_screen(cit_screen);
 }
 


### PR DESCRIPTION
1. Instead of hardcoding a 640x480 canvas size, use the resolution of
   the current screen canvas
2. Use 'svga_screen' instead of 'cit_screen' for the automap loop, as
   only the former is resized in change_svga_screen_mode()

fixes #20