### PR TITLE
Make game window resizable, implement fullscreen mode

### DIFF
--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -95,6 +95,9 @@ void mac_set_mode(void)
     SDL_SetWindowSize(window, width, height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
+    extern SDL_Renderer* renderer;
+    SDL_RenderSetLogicalSize(renderer, width, height);
+
     extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
     gScreenWide = width;
     gScreenHigh = height;

--- a/src/Libraries/INPUT/Source/mouse.c
+++ b/src/Libraries/INPUT/Source/mouse.c
@@ -171,36 +171,17 @@ pascal void MousePollProc(void)
 	short		i;
 	mouse_event	e;
 
-	int mouse_x = -1;
-	int mouse_y = -1;
-	
-	//printf("%i %i\n", mouse_x, mouse_y);
+	extern mouse_event latestMouseEvent;
+	mouseInstantButts = latestMouseEvent.buttons;
 
-	//mp.h = mouse_x;
-	//mp.v = mouse_y;
-
-	STUB_ONCE("TODO: Get mouse x and y?")
-	uint mouse_state = SDL_GetMouseState(&mouse_x, &mouse_y);
-
-	mouseInstantButts = 0;
-
-	if(mouse_state & SDL_BUTTON(SDL_BUTTON_LEFT)) {
-		mouseInstantButts = 1;
-	}
-
-	if(mouse_state & SDL_BUTTON(SDL_BUTTON_RIGHT)) {
-		mouseInstantButts = 2;
-	}
-
-	if (mouseInstantX != mouse_x || mouseInstantY != mouse_y)						// If different
+	if (mouseInstantX != latestMouseEvent.x || mouseInstantY != latestMouseEvent.y)		// If different
 	{
-		mouseInstantX = mouse_x;												// save the position
-		mouseInstantY = mouse_y;
+		mouseInstantX = latestMouseEvent.x;						// save the position
+		mouseInstantY = latestMouseEvent.y;
 		
-		e.x = mouse_x;																// and inform the callback routines
-		e.y = mouse_y;
+		mouse_event e = latestMouseEvent;
 		e.type = MOUSE_MOTION;
-		e.buttons = mouseInstantButts;
+
 		for (i = 0; i < mouseCalls; i++)
 			if(mouseCall[i] !=NULL)
 				mouseCall[i](&e,mouseCallData[i]);
@@ -454,6 +435,7 @@ void _mouse_update_vel(void)
 //	---------------------------------------------------------
 //  For Mac version: Use GetMouse().
 
+#if 0 // moved to sdl_events.c
 errtype mouse_get_xy(short* x, short* y)
 {
 	int x_, y_;
@@ -508,7 +490,6 @@ errtype mouse_put_xy(short x, short y)
 	RawMouse->h = pt.h; 	
  
  	*CrsrNew=1;
-#endif
 
 	return OK;*/
 
@@ -541,6 +522,7 @@ errtype mouse_put_xy(short x, short y)
    return OK;
 */
 }
+#endif
 
 // --------------------------------------------------------
 // mouse_check_btn checks button state.  

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -89,6 +89,7 @@ Boolean				gGameCompletedQuit;
 
 grs_screen  *cit_screen;
 SDL_Window* window;
+SDL_Renderer* renderer;
 
 extern grs_screen *svga_screen;
 extern 	frc *svga_render_context;
@@ -345,7 +346,7 @@ void InitSDL()
 
 	window = SDL_CreateWindow(
 		"System Shock - Shockolate 0.5", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-		grd_cap->w, grd_cap->h, SDL_WINDOW_SHOWN);
+		grd_cap->w, grd_cap->h, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 
 	// Setup the screen
 
@@ -360,7 +361,8 @@ void InitSDL()
 
 	SDL_RaiseWindow(window);
 	
-	SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
+	renderer = SDL_CreateRenderer(window, -1, 0);
+	SDL_RenderSetLogicalSize(renderer, gScreenWide, gScreenHigh);
 
 	SDLDraw();
 }
@@ -387,10 +389,12 @@ void SetSDLPalette(int index, int count, uchar *pal)
 	SDL_SetSurfacePalette(offscreenDrawSurface, sdlPalette);
 }
 
-SDL_Rect destRect;
 void SDLDraw()
 {
-	SDL_Surface* screenSurface = SDL_GetWindowSurface( window );
-	SDL_BlitSurface(drawSurface, NULL, screenSurface, NULL);
-  	SDL_UpdateWindowSurface(window);
+	SDL_RenderClear(renderer);
+	SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, drawSurface);
+	SDL_Rect srcRect = { 0, 0, gScreenWide, gScreenHigh };
+	SDL_RenderCopy(renderer, texture, &srcRect, NULL);
+	SDL_DestroyTexture(texture);
+	SDL_RenderPresent(renderer);
 }


### PR DESCRIPTION
1. Use SDL_Renderer to blit the draw surface onto the screen
2. Make the game window resizable
3. Move mouse_get_xy() and mouse_put_xy() from mouse.c to sdl_events.c;
   in the latter function, scale from game coordinates to window
   coordinates
4. Implement Alt+Enter hotkey to toggle fullscreen mode