### PR TITLE
Fix drawing order of two-dimensional objects

### DIFF
--- a/src/GameSrc/gamesort.c
+++ b/src/GameSrc/gamesort.c
@@ -84,7 +84,7 @@ static uchar    partition_type;
 static uchar    partition_cnt;
 
 static uint     cur_obj_num, draw_last_cnt;
-static uint     osort_zc, osort_yc, osort_xc;			// KLC - changed order for our compiler (it puts them in reverse order)
+static uint     osort_xc, osort_yc, osort_zc;
 
 // set up data space, 
 void render_sort_start(void)
@@ -209,7 +209,7 @@ int do_part_sort(int ptype, int lo, int hi, int ploc)
    part_obj=&objs[sq_Refs[ploc]];
    pdir=(ptype==PRT_VERT)?2:(part_obj->loc.h&0x40)?0:1;
    get_part_val(part_val,part_obj,pdir);
-   cam_val=*((&osort_xc)+pdir);
+   cam_val = pdir == 0 ? osort_xc : pdir == 1 ? osort_yc : osort_zc;
    near_f=(cam_val<part_val);
 
    if ((lo<=ploc)&&(ploc<hi))


### PR DESCRIPTION
The algorithm for sorting objects to determine draw order uses three
local variables holding the camera position, and expects them to be in
subsequent memory locations. Apparently the Mac developers ran into an
issue with their compiler placing the variables in reverse order and
"fixed" it by swapping the declaration order.

Use a portable expression to get the right coordinate instead of relying
on compiler interals. This fixes an issue with a control pedestal being
visible through an opaque bridge right at the beginning of the game when
compiling with gcc.