### PR TITLE
Fix double key events when editing a map note

### DIFF
--- a/src/GameSrc/amaploop.c
+++ b/src/GameSrc/amaploop.c
@@ -776,7 +776,7 @@ uchar amap_kb_callback(curAMap *amptr, int code)
    
    if (cur_mapnote_ptr!=NULL)
    {
-//KLC - we'll do keydowns      if ((code&KB_FLAG_DOWN)==KB_FLAG_DOWN) return TRUE;
+      if (!(code & KB_FLAG_DOWN)) return TRUE;
       code = kb2ascii(code);
 //KLC      if ((code==KEY_ENTER)||(code==KEY_DEL))
       if (code==KEY_ENTER)												// If we've pressed Enter


### PR DESCRIPTION
When editing a map note, all key events are handled twice: once when
pressing and once when releasing the key.