### PR TITLE
Unifying game loops, death sends you back to the main menu

### DIFF
--- a/src/GameSrc/Headers/mainloop.h
+++ b/src/GameSrc/Headers/mainloop.h
@@ -64,6 +64,7 @@ void mainloop(int argc, char *argv[]);
 void loopmode_switch(short *cmode);
 errtype static_change_copy();
 void loopmode_exit(short loopmode);
+void loopmode_enter(short loopmode);
 
 #ifdef __MAINLOOP_SRC
 frc *_current_fr_context;

--- a/src/GameSrc/damage.c
+++ b/src/GameSrc/damage.c
@@ -450,9 +450,11 @@ uchar kill_player(void)
    if (quick_death)
    {
       amap_reset();
-     secret_render_fx=0;
-     gDeadPlayerQuit = TRUE;
-	 gPlayingGame = FALSE;															// Hop out of the game loop.
+      secret_render_fx=0;
+
+      // CC: Go back to the main menu, should really play the death custcene here
+      _new_mode = SETUP_LOOP;
+      chg_set_flg(GL_CHG_LOOP);
    }
 
    return(quick_death | alternate_death);

--- a/src/GameSrc/gamesys.c
+++ b/src/GameSrc/gamesys.c
@@ -984,9 +984,14 @@ void do_stuff_every_second()
 		if(remain<CIT_CYCLE)
 		{
 			secret_render_fx=0;
-//KLC            play_cutscene(ENDGAME_CUTSCENE,TRUE);
-			gDeadPlayerQuit = TRUE;											// Pretend the player is dead.
-			gPlayingGame = FALSE;											// Hop out of the game loop.
+         //play_cutscene(ENDGAME_CUTSCENE,TRUE);
+
+         // CC: Back to the main menu until there's a real endgame cutscene again
+         _new_mode = SETUP_LOOP;
+         chg_set_flg(GL_CHG_LOOP);
+
+			//gDeadPlayerQuit = TRUE;											// Pretend the player is dead.
+			//gPlayingGame = FALSE;											// Hop out of the game loop.
 		}
 	}
 

--- a/src/GameSrc/mainloop.c
+++ b/src/GameSrc/mainloop.c
@@ -116,7 +116,7 @@ void loopmode_enter(short loopmode)
    (*enter_modes[loopmode])();
 }
 
-void ShockMain(void)
+void mainloop(int argc, char *argv[])
 {
     extern void SDLDraw(void);
     extern long gShockTicks;

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -1286,7 +1286,7 @@ void splash_draw()
 
    ResCloseFile(pal_file);
 
-   // Startup some music!
+   // Startup music
    start_setup_sound(0);
 }
 
@@ -1350,7 +1350,7 @@ void setup_start()
    save_game_exists = (valid_save != 0);
 
    // FIXME: Should fix play_intro_anim
-   start_first_time = FALSE;
+   // start_first_time = FALSE;
 
    if (setup_mode != SETUP_CREDITS)
    {
@@ -1369,6 +1369,7 @@ void setup_start()
    {
 //      start_setup_sound();
       closedown_game(TRUE);
+      start_setup_sound(0);
    }
    start_first_time = FALSE;
 
@@ -1454,6 +1455,9 @@ void setup_start()
 
       // FIXME: Cutscenes!
       //play_cutscene(START_CUTSCENE, TRUE);
+
+      // CC: Just play some music for now instead
+      start_setup_sound(0);
    }
 }
 

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -103,9 +103,8 @@ extern void inv_change_fullscreen(uchar on);
 extern void object_data_flush(void);
 //extern Boolean IsFullscreenWareOn(void);
 extern errtype load_da_palette(void);
+extern void ShockMain(void);
 
-void ShockGameLoop(void);
-void ShockSetupLoop(void);
 void InitSDL();
 void SDLDraw(void);
 errtype CheckFreeSpace(short	checkRefNum);
@@ -132,156 +131,34 @@ int main(int argc, char** argv)
 	// Initialize
 
 	init_all();
-	
-	/*if (gShockPrefs.prefPlayIntro)
-	{
-		extern void PlayIntroCutScene(void);
-		PlayIntroCutScene();
-		gShockPrefs.prefPlayIntro = 0;
-		SavePrefs(kPrefsResID);
-	}*/
-
-	extern errtype load_savegame_names(void);
-	load_savegame_names();
-	
-	printf("Showing title screen\n");
-
-	ShockSetupLoop();
-
-	ShockGameLoop();
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------------
-//		Handle Quit menu command/apple event.
-//------------------------------------------------------------------------------------
-void DoQuit(void)
-{
-//	if (AskToSave(1))
-//	{
-//		if (modeflag!=-1)
-//			EndGame(false);
-		gDone = true;
-//	}
-}
-
-//--------------------------------------------------------------------
-//  The main game loop for System Shock.
-//--------------------------------------------------------------------
-extern pascal void MousePollProc(void);
-extern void pump_events(void);
-extern long gShockTicks;
-
-void ShockSetupLoop(void)
-{
-	// CC: Should unify all loops together into one master loop, like they used to be
-	_new_mode = _current_loop = SETUP_LOOP;
-
 	setup_init();
-	setup_start();
-	load_da_palette();		// KLC - added here.  Used to be in setup_start().
 
-	/*if (startup_music)
-	{
-		start_music();
-	}*/
-
-	gr_clear(0xFF);
-
-	splash_draw();
-
-	while(_current_loop == SETUP_LOOP) {
-
-		gShockTicks = TickCount();
-
-		if (!(_change_flag&(ML_CHG_BASE<<1)))
-			input_chk();
-		
-		// DG: at the beginning of each frame, get all the events from SDL
-		pump_events();
-
-		if (globalChanges)
-		{
-			if (_change_flag&(ML_CHG_BASE<<3))
-				loopmode_switch(&_current_loop);
-			chg_unset_flg(ML_CHG_BASE<<3);
-		}
-
-		if(_current_loop == SETUP_LOOP) {
-			setup_loop();
-		}
-
-		chg_set_flg(_static_change);
-
-		MousePollProc();		// update the cursor, was 35 times/sec originally
-
-		// FIXME: should draw this bio bar again
-		// status_bio_update();	// draw the biometer
-
-		SDLDraw();
-	}
-}
-
-void ShockGameLoop(void)
-{
 	gPlayingGame = TRUE;
 	gDeadPlayerQuit = FALSE;
 	gGameCompletedQuit = FALSE;
 
-	gr_clear(0x0);
-	load_da_palette();		// KLC - added here.  Used to be in setup_start().
+	// Start in the Main Menu loop
 
-	if (IsFullscreenWareOn())
-	{
-		fullscreen_start();
-		_new_mode = _current_loop = FULLSCREEN_LOOP;
-	}
-	else
-	{
-		screen_start();											// Initialize the screen for slot view.
-		_new_mode = _current_loop = GAME_LOOP;
-	}
+	_new_mode = _current_loop = SETUP_LOOP;
+	loopmode_enter(SETUP_LOOP);
 
-	while (gPlayingGame)
-	{	
-		gShockTicks = TickCount();
+	// Draw the splash screen
 
-		if (!(_change_flag&(ML_CHG_BASE<<1)))
-			input_chk();
-		
-		// DG: at the beginning of each frame, get all the events from SDL
-		pump_events();
+	load_da_palette();
+	gr_clear(0xFF);
 
-		if (globalChanges)
-		{
-			if (_change_flag&(ML_CHG_BASE<<3))
-				loopmode_switch(&_current_loop);
-			chg_unset_flg(ML_CHG_BASE<<3);
-		}
-		
-		if (_current_loop == SETUP_LOOP)
-			setup_loop();
-		else if (_current_loop == AUTOMAP_LOOP)
-			automap_loop();									// Do the fullscreen map loop.
-		else {
-			game_loop();										// Run the game!
-		}
-		
-		chg_set_flg(_static_change);
+	printf("Showing splash screen\n");
+	splash_draw();
 
-		MousePollProc();		// update the cursor, was 35 times/sec originally
-		status_bio_update();	// draw the biometer
+	// Start the main loop
 
-		SDLDraw();
-	}
+	printf("Showing main menu, starting game loop\n");
+	ShockMain();
 
-	if(gGameCompletedQuit) {
-		// FIXME: Revive the old cutscenes!
-		printf("SHODAN has been defeated!\n");
-	}
+	status_bio_end();
+    stop_music();
 
-	/*
+    /*
 	// We're through playing now.
 	uiHideMouse(NULL);
 	loopmode_exit(_current_loop);
@@ -308,6 +185,21 @@ void ShockGameLoop(void)
 
 	closedown_game(TRUE);
 	*/
+
+	return 0;
+}
+
+//------------------------------------------------------------------------------------
+//		Handle Quit menu command/apple event.
+//------------------------------------------------------------------------------------
+void DoQuit(void)
+{
+//	if (AskToSave(1))
+//	{
+//		if (modeflag!=-1)
+//			EndGame(false);
+		gDone = true;
+//	}
 }
 
 #define NEEDED_DISKSPACE   700000

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
 	// Start the main loop
 
 	printf("Showing main menu, starting game loop\n");
-	ShockMain();
+	mainloop(argc, argv);
 
 	status_bio_end();
     stop_music();


### PR DESCRIPTION
This revives the `mainloop` function inside `mainloops.c` and makes it so that death switches back over to the main menu screen instead of just quitting.