### PR TITLE
Add checks to prevent texture map overflow

### DIFF
--- a/src/Libraries/2D/Source/Flat8/fl8lnop.c
+++ b/src/Libraries/2D/Source/Flat8/fl8lnop.c
@@ -36,7 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "poly.h"
 #include "tmapint.h"
 #include "vtab.h"
-#include <stdio.h>
 
 // prototypes
 int gri_lin_umap_loop(grs_tmap_loop_info *tli);
@@ -173,12 +172,11 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                 }
                 break;
             case GRL_OPAQUE | GRL_LOG2:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = ((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask;
                     *(p_dest++) = t_bits[k]; // gr_fill_upixel(t_bits[k],x,y);
                     u += du;
                     v += dv;
-                    if (v < 0) printf("potential V overflow threat detected\n");                    
                 }
                 break;
             case GRL_TRANS | GRL_LOG2:
@@ -218,14 +216,13 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                         }
                         break;*/
             case GRL_TRANS | GRL_LOG2 | GRL_CLUT:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = ((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask;
                     if (k = t_bits[k])
                         *p_dest = t_clut[k]; // gr_fill_upixel(tli->clut[k],x,y);
                     p_dest++;
                     u += du;
                     v += dv;
-                    if (v < 0) printf("potential V overflow threat detected\n");
                 }
                 break;
             }

--- a/src/Libraries/2D/Source/Flat8/fl8lnop.c
+++ b/src/Libraries/2D/Source/Flat8/fl8lnop.c
@@ -36,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "poly.h"
 #include "tmapint.h"
 #include "vtab.h"
+#include <stdio.h>
 
 // prototypes
 int gri_lin_umap_loop(grs_tmap_loop_info *tli);
@@ -154,7 +155,7 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
 
             switch (tli->bm.hlog) {
             case GRL_OPAQUE:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = t_vtab[fix_fint(v)] + fix_fint(u);
                     *(p_dest++) = t_bits[k]; // gr_fill_upixel(t_bits[k],x,y);
                     u += du;
@@ -162,7 +163,7 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                 }
                 break;
             case GRL_TRANS:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = t_vtab[fix_fint(v)] + fix_fint(u);
                     if (temp_pix = t_bits[k])
                         *p_dest = temp_pix; // gr_fill_upixel(t_bits[k],x,y);
@@ -177,10 +178,11 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                     *(p_dest++) = t_bits[k]; // gr_fill_upixel(t_bits[k],x,y);
                     u += du;
                     v += dv;
+                    if (v < 0) printf("potential V overflow threat detected\n");                    
                 }
                 break;
             case GRL_TRANS | GRL_LOG2:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = ((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask;
                     if (temp_pix = t_bits[k])
                         *p_dest = temp_pix; // gr_fill_upixel(t_bits[k],x,y);
@@ -190,7 +192,7 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                 }
                 break;
             case GRL_OPAQUE | GRL_CLUT:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = t_vtab[fix_fint(v)] + fix_fint(u);
                     *(p_dest++) = t_clut[t_bits[k]]; // gr_fill_upixel(tli->clut[t_bits[k]],x,y);
                     u += du;
@@ -198,7 +200,7 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                 }
                 break;
             case GRL_TRANS | GRL_CLUT:
-                for (; x > 0; x--) {
+                for (; x > 0 && v >= 0; x--) {
                     k = t_vtab[fix_fint(v)] + fix_fint(u);
                     if (k = t_bits[k])
                         *p_dest = t_clut[k]; // gr_fill_upixel(tli->clut[k],x,y);
@@ -223,6 +225,7 @@ int gri_lin_umap_loop(grs_tmap_loop_info *tli) {
                     p_dest++;
                     u += du;
                     v += dv;
+                    if (v < 0) printf("potential V overflow threat detected\n");
                 }
                 break;
             }


### PR DESCRIPTION
Bug description: crash potential when texture V coordinate is negative.

```
/* converts the floor of n to an integer. */
#define fix_fint(n) ((n) >> 16)

k = t_vtab[fix_fint(v)] + fix_fint(u);
if (k = t_bits[k])
    *p_dest = t_clut[k];
```

What happens here is that because negative numbers actually look like really large positive numbers (-1 looks like 0xFFFFFFFF etc.), `fix_fint` converts small negative values of `v` into 0xFFFF, and whatever junk happens to be at `t_vtab[0xFFFF]` then becomes the **index** of `t_bits` that the code reads. Whenever this index happens to be broken enough, the game crashes.

Fix: prevent negative values of `v`. 