### PR TITLE
Implement persistent preferences

### DIFF
--- a/src/GameSrc/gamestrn.c
+++ b/src/GameSrc/gamestrn.c
@@ -59,8 +59,11 @@ char which_lang;
 void init_strings(void)
 {
 	// Open the string resource file.
-   printf("Loading cybstrng.res\n");
-	string_res_file = ResOpenFile("res/data/cybstrng.res");
+	if (which_lang < 0 || which_lang >= sizeof(language_files) / sizeof(*language_files))
+		which_lang = 0;
+	const uchar *lang_file = language_files[which_lang];
+	printf("Loading %s\n", lang_file);
+	string_res_file = ResOpenFile(lang_file);
 	
 	if (string_res_file < 0)
 		critical_error(CRITERR_RES|0);

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -54,6 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "gr2ss.h"
 #include "player.h"
 #include "popups.h"
+#include "Prefs.h"
 
 /*
 #include <olhext.h>
@@ -1187,6 +1188,7 @@ errtype wrapper_panel_close(uchar clear_message)
    if (clear_message)
       message_info("");
    wrapper_panel_on = FALSE;
+   SavePrefs(0);
    inventory_page = inv_last_page;
    if (inventory_page < 0 && inventory_page != INV_3DVIEW_PAGE)
       inventory_page = 0;

--- a/src/MacSrc/Prefs.h
+++ b/src/MacSrc/Prefs.h
@@ -46,6 +46,7 @@ typedef struct
 	short		soMusicVolume;
 	
 	// Display Options
+	short		doVideoMode;
 	short		doResolution;			// 0 - High, 1 - Low
 	short		doDetail;				// 0 - Min, 1-Low, 2-High, 3-Max
 	short		doGamma;
@@ -68,4 +69,3 @@ extern ShockPrefs		gShockPrefs;
 void SetDefaultPrefs(void);
 OSErr LoadPrefs(ResType resID);
 OSErr SavePrefs(ResType resID);
-OSErr GetPrefsDir(short *vRef, long *parID);

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 	InitMac();															// init mac managers
 
 	SetDefaultPrefs();													// Initialize the preferences file.
-	//LoadPrefs(kPrefsResID);
+	LoadPrefs(kPrefsResID);
 	
 #ifdef TESTING
 	SetupTests();


### PR DESCRIPTION
Save a few configuration options (most notably: screen resolution and
language) into a global configuration file. Instead of saving to a
binary resource file (as the Mac version did), just write a super-simple
and easily extensible text file.