### PR TITLE
Cleanup: Remove resID parameter from Load/SavePrefs()

### DIFF
--- a/src/GameSrc/hkeyfunc.c
+++ b/src/GameSrc/hkeyfunc.c
@@ -291,7 +291,7 @@ void start_music(void) {
         MacTuneStartCurrentTheme();
     } else {
         gShockPrefs.soBackMusic = FALSE;
-        SavePrefs(kPrefsResID);
+        SavePrefs();
     }
     //   }
 }
@@ -319,7 +319,7 @@ uchar toggle_music_func(short keycode, ulong context, void *data) {
     }
 
     gShockPrefs.soBackMusic = music_on;
-    SavePrefs(kPrefsResID);
+    SavePrefs();
 
     return (FALSE);
 }

--- a/src/GameSrc/input.c
+++ b/src/GameSrc/input.c
@@ -1114,7 +1114,7 @@ uchar MacResFunc(short keycode, ulong context, void *data) {
     }
     gShockPrefs.doResolution = (DoubleSize) ? 1 : 0; // KLC - Yeah, got to update this one too
     gShockPrefs.doUseQD = SkipLines;                 // KLC - and this one
-    SavePrefs(kPrefsResID);                          // KLC - and save the prefs out to disk.
+    SavePrefs();                                     // KLC - and save the prefs out to disk.
 
     return TRUE;
 }
@@ -1127,7 +1127,7 @@ uchar MacSkiplinesFunc(short keycode, ulong context, void *data) {
     }
     SkipLines = !SkipLines;
     gShockPrefs.doUseQD = SkipLines;
-    SavePrefs(kPrefsResID);
+    SavePrefs();
     return TRUE;
 }
 
@@ -1145,7 +1145,7 @@ uchar MacDetailFunc(short keycode, ulong context, void *data) {
     _fr_global_detail = _frc->detail; // Update the global guy.
 
     gShockPrefs.doDetail = _frc->detail; // Update and save our prefs.
-    SavePrefs(kPrefsResID);
+    SavePrefs();
 
     switch (_frc->detail) // Show a nice, informative message.
     {

--- a/src/GameSrc/musicai.c
+++ b/src/GameSrc/musicai.c
@@ -729,7 +729,7 @@ errtype music_init() {
         } else // else turn off the music globals and prefs
         {
             gShockPrefs.soBackMusic = FALSE;
-            SavePrefs(kPrefsResID);
+            SavePrefs();
             music_on = mlimbs_on = FALSE;
         }
         //	}

--- a/src/GameSrc/olh.c
+++ b/src/GameSrc/olh.c
@@ -502,7 +502,7 @@ uchar toggle_olh_func(short keycode, ulong context, void *data) {
         ResUnlock(RES_olh_strings); // KLC - added to free strings.
     }
     gShockPrefs.goOnScreenHelp = olh_active; // KLC - Yeah, got to update this one too and
-    SavePrefs(kPrefsResID);                  // KLC - save the prefs out to disk.
+    SavePrefs();                             // KLC - save the prefs out to disk.
     return TRUE;
 }
 

--- a/src/GameSrc/trigger.c
+++ b/src/GameSrc/trigger.c
@@ -1121,7 +1121,7 @@ errtype trap_questbit_func(int p1, int p2, int p3, int p4) {
         olh_active = FALSE; // KLC - this is kept in a global now.
 
         gShockPrefs.goOnScreenHelp = FALSE; // Yeah, got to update this one too and
-        SavePrefs(kPrefsResID);             // save the prefs out to disk.
+        SavePrefs();                        // save the prefs out to disk.
         return (OK);
     }
 

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -1119,7 +1119,7 @@ errtype wrapper_panel_close(uchar clear_message) {
     if (clear_message)
         message_info("");
     wrapper_panel_on = FALSE;
-    SavePrefs(0);
+    SavePrefs();
     inventory_page = inv_last_page;
     if (inventory_page < 0 && inventory_page != INV_3DVIEW_PAGE)
         inventory_page = 0;

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -6,15 +6,15 @@ This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 */
 //====================================================================================
 //
@@ -23,7 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //		Prefs.c	-	Handles saving and loading preferences.
 //
 //====================================================================================
-
 
 //--------------------
 //  Includes
@@ -39,16 +38,16 @@ static void SetShockGlobals(void);
 //--------------------
 //  Globals
 //--------------------
-ShockPrefs		gShockPrefs;
-char		which_lang;
+ShockPrefs gShockPrefs;
+char which_lang;
 uchar sfx_on = TRUE;
 
 //--------------------
 //  Externs
 //--------------------
-extern int 		_fr_global_detail;
-extern Boolean	DoubleSize;
-extern Boolean	SkipLines;
+extern int _fr_global_detail;
+extern Boolean DoubleSize;
+extern Boolean SkipLines;
 extern short mode_id;
 
 extern uchar curr_vol_lev;
@@ -68,29 +67,28 @@ static const char *PREF_DETAIL       = "detail";
 //--------------------------------------------------------------------
 //	  Initialize the preferences to their default settings.
 //--------------------------------------------------------------------
-void SetDefaultPrefs(void)
-{
-	gShockPrefs.prefVer = 0;
-	gShockPrefs.prefPlayIntro = 1;				// First time through, play the intro
-	
-	gShockPrefs.goMsgLength = 0;				// Normal
-	gShockPrefs.goPopupLabels = true;
-	gShockPrefs.goOnScreenHelp = true;
-	gShockPrefs.goLanguage = 0;					// English
+void SetDefaultPrefs(void) {
+    gShockPrefs.prefVer = 0;
+    gShockPrefs.prefPlayIntro = 1;      // First time through, play the intro
 
-	gShockPrefs.soBackMusic = true;
-	gShockPrefs.soSoundFX = true;
-	gShockPrefs.soMusicVolume = 100;
-	gShockPrefs.soSfxVolume = 100;
-	gShockPrefs.soAudioLogVolume = 100;
+    gShockPrefs.goMsgLength = 0;        // Normal
+    gShockPrefs.goPopupLabels = true;
+    gShockPrefs.goOnScreenHelp = true;
+    gShockPrefs.goLanguage = 0;         // English
 
-	gShockPrefs.doVideoMode = 3;
-	gShockPrefs.doResolution = 0;				// High-res.
-	gShockPrefs.doDetail = 3;					// Max detail.
-	gShockPrefs.doGamma = 29;					// Default gamma (29 out of 100).
-	gShockPrefs.doUseQD = false;
+    gShockPrefs.soBackMusic = true;
+    gShockPrefs.soSoundFX = true;
+    gShockPrefs.soMusicVolume = 100;
+    gShockPrefs.soSfxVolume = 100;
+    gShockPrefs.soAudioLogVolume = 100;
 
-	SetShockGlobals();
+    gShockPrefs.doVideoMode = 3;
+    gShockPrefs.doResolution = 0;       // High-res.
+    gShockPrefs.doDetail = 3;           // Max detail.
+    gShockPrefs.doGamma = 29;           // Default gamma (29 out of 100).
+    gShockPrefs.doUseQD = false;
+
+    SetShockGlobals();
 }
 
 static FILE *open_prefs(const char *mode) {
@@ -102,9 +100,11 @@ static FILE *open_prefs(const char *mode) {
 }
 
 static char *trim(char *s) {
-    while (*s && isspace(*s)) s++;
+    while (*s && isspace(*s))
+        s++;
     char *c = &s[strlen(s) - 1];
-    while (c >= s && isspace(*c)) *(c--) = '\0';
+    while (c >= s && isspace(*c))
+        *(c--) = '\0';
     return s;
 }
 
@@ -115,11 +115,11 @@ static bool is_true(const char *s) {
 //--------------------------------------------------------------------
 //	  Locate the preferences file and load them to set our global pref settings.
 //--------------------------------------------------------------------
-OSErr LoadPrefs(ResType resID) {
+OSErr LoadPrefs(void) {
     FILE *f = open_prefs("r");
     if (!f) {
         // file can't be open, write default preferences
-        return SavePrefs(resID);
+        return SavePrefs();
     }
 
     char line[64];
@@ -173,8 +173,8 @@ OSErr LoadPrefs(ResType resID) {
 //--------------------------------------------------------------------
 //	  Save global settings in the preferences file.
 //--------------------------------------------------------------------
-OSErr SavePrefs(ResType resID)  {
-    printf("Saving preferences\n");
+OSErr SavePrefs(void) {
+    INFO("Saving preferences\n");
     FILE *f = open_prefs("w");
     if (!f) {
         printf("ERROR: Failed to open preferences file\n");
@@ -196,19 +196,18 @@ OSErr SavePrefs(ResType resID)  {
 //--------------------------------------------------------------------
 //  Set the corresponding Shock globals from the prefs structure.
 //--------------------------------------------------------------------
-static void SetShockGlobals(void)
-{
-	popup_cursors = gShockPrefs.goPopupLabels;
-	olh_active = gShockPrefs.goOnScreenHelp;
-	which_lang = gShockPrefs.goLanguage;
+static void SetShockGlobals(void) {
+    popup_cursors = gShockPrefs.goPopupLabels;
+    olh_active = gShockPrefs.goOnScreenHelp;
+    which_lang = gShockPrefs.goLanguage;
 
-	sfx_on = gShockPrefs.soSoundFX;
-	curr_vol_lev = gShockPrefs.soMusicVolume;
-	curr_sfx_vol = gShockPrefs.soSfxVolume;
-	curr_alog_vol = gShockPrefs.soAudioLogVolume;
+    sfx_on = gShockPrefs.soSoundFX;
+    curr_vol_lev = gShockPrefs.soMusicVolume;
+    curr_sfx_vol = gShockPrefs.soSfxVolume;
+    curr_alog_vol = gShockPrefs.soAudioLogVolume;
 
-	mode_id = gShockPrefs.doVideoMode;
-	DoubleSize = (gShockPrefs.doResolution == 1);		// Set this True for low-res.
-	SkipLines = gShockPrefs.doUseQD;
-	_fr_global_detail = gShockPrefs.doDetail;
+    mode_id = gShockPrefs.doVideoMode;
+    DoubleSize = (gShockPrefs.doResolution == 1); // Set this True for low-res.
+    SkipLines = gShockPrefs.doUseQD;
+    _fr_global_detail = gShockPrefs.doDetail;
 }

--- a/src/MacSrc/Prefs.h
+++ b/src/MacSrc/Prefs.h
@@ -6,15 +6,15 @@ This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 */
 //====================================================================================
 //
@@ -29,45 +29,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //--------------------
 //  Types
 //--------------------
-typedef struct 
-{
-	short		prefVer;				// Version - set to 0 for now.
-	short		prefPlayIntro;			// Play intro at startup if non-zero.
-	
-	// Game Options
-	short		goMsgLength;			// 0 - normal, 1 - brief
-	Boolean		goPopupLabels;
-	Boolean		goOnScreenHelp;
-	short		goLanguage;				// 0 - English
-	
-	// Sound Options
-	Boolean		soBackMusic;
-	Boolean		soSoundFX;
-	short		soMusicVolume;
-	short		soSfxVolume;
-	short		soAudioLogVolume;
-	
-	// Display Options
-	short		doVideoMode;
-	short		doResolution;			// 0 - High, 1 - Low
-	short		doDetail;				// 0 - Min, 1-Low, 2-High, 3-Max
-	short		doGamma;
-	Boolean	doUseQD;
-	
-} ShockPrefs;
+typedef struct {
+    short prefVer;              // Version - set to 0 for now.
+    short prefPlayIntro;        // Play intro at startup if non-zero.
 
-#define kPrefsFileType 		'Sprf'
-#define	kPrefsFileName		"System Shock Prefs"
-#define kPrefsResID			'Pref'
+    // Game Options
+    short goMsgLength;          // 0 - normal, 1 - brief
+    Boolean goPopupLabels;
+    Boolean goOnScreenHelp;
+    short goLanguage;           // 0 - English, 1 - French, 2 - German
+
+    // Sound Options
+    Boolean soBackMusic;
+    Boolean soSoundFX;
+    short soMusicVolume;
+    short soSfxVolume;
+    short soAudioLogVolume;
+
+    // Display Options
+    short doVideoMode;
+    short doResolution;         // 0 - High, 1 - Low
+    short doDetail;             // 0 - Min, 1-Low, 2-High, 3-Max
+    short doGamma;
+    Boolean doUseQD;
+} ShockPrefs;
 
 //--------------------
 //  Globals
 //--------------------
-extern ShockPrefs		gShockPrefs;
+extern ShockPrefs gShockPrefs;
 
 //--------------------
 //  Prototypes
 //--------------------
 void SetDefaultPrefs(void);
-OSErr LoadPrefs(ResType resID);
-OSErr SavePrefs(ResType resID);
+OSErr LoadPrefs(void);
+OSErr SavePrefs(void);

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 	InitMac();															// init mac managers
 
 	SetDefaultPrefs();													// Initialize the preferences file.
-	LoadPrefs(kPrefsResID);
+	LoadPrefs();
 	
 #ifdef TESTING
 	SetupTests();


### PR DESCRIPTION
No longer needed since we store preferences as plain text.