### PR TITLE
Handle mouse wheel events

### DIFF
--- a/src/GameSrc/amaploop.c
+++ b/src/GameSrc/amaploop.c
@@ -558,6 +558,13 @@ uchar amap_ms_callback(curAMap *amptr, int x, int y, short action, ubyte b) {
     extern void mouse_unconstrain(void);
     int scregion = 0;
 
+    if (action & (MOUSE_WHEELUP | MOUSE_WHEELDN)) {
+        if (zoom_deal(amptr, action & MOUSE_WHEELUP ? BTN_ZOOMIN : BTN_ZOOMOUT))
+            chg_set_flg(AMAP_MAP_EV);
+        pend_check();
+        return TRUE;
+    }
+
     if (action & MOUSE_UPS) {
         mouse_unconstrain();
         if (map_scroll_code != 0) {

--- a/src/GameSrc/automap.c
+++ b/src/GameSrc/automap.c
@@ -139,6 +139,14 @@ uchar mfd_map_handler(MFD *m, uiEvent *e) {
         return FALSE;
 
     mouse = (uiMouseEvent *)e;
+
+    if (mouse->action & (MOUSE_WHEELUP | MOUSE_WHEELDN)) {
+        if (!digi_fx_playing(SFX_MAP_ZOOM, NULL))
+            play_digi_fx(SFX_MAP_ZOOM, 1);
+        amap_zoom(oAMap(mapid), FALSE, mouse->action & MOUSE_WHEELUP ? 1 : -1);
+        return TRUE;
+    }
+
     if (!(mouse->action & MOUSE_LDOWN))
         return FALSE; // ignore click releases
 

--- a/src/GameSrc/fullamap.c
+++ b/src/GameSrc/fullamap.c
@@ -49,9 +49,8 @@ void amap_exit(void);
 
 uchar amap_mouse_handler(uiEvent *ev, LGRegion *reg, void *v) {
     uiMouseEvent *mev = (uiMouseEvent *)ev;
-    if (mev->action & ~MOUSE_MOTION)
-        if (mev->action < 8)
-            return amap_ms_callback(oAMap(MFD_FULLSCR_MAP), mev->pos.x, mev->pos.y, mev->action, mev->buttons);
+    if (mev->action & (MOUSE_LDOWN | MOUSE_LUP | MOUSE_WHEELUP | MOUSE_WHEELDN))
+        return amap_ms_callback(oAMap(MFD_FULLSCR_MAP), mev->pos.x, mev->pos.y, mev->action, mev->buttons);
     return (TRUE);
 }
 

--- a/src/GameSrc/input.c
+++ b/src/GameSrc/input.c
@@ -2263,6 +2263,11 @@ uchar view3d_mouse_handler(uiMouseEvent *ev, LGRegion *r, view3d_data *data) {
         data->lastleft = MakePoint(-100, -100);
     }
 
+    if (ev->action & (MOUSE_WHEELUP | MOUSE_WHEELDN)) {
+        extern uchar cycle_weapons_func(ushort keycode, ulong context, int data);
+        cycle_weapons_func(0, 0, ev->action & MOUSE_WHEELUP ? -1 : 1);
+    }
+
     // data->ldown = TRUE;
 
     // Do mouse motion.

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -91,6 +91,7 @@ extern void text_button(char *text, int xc, int yc, int col, int shad, int w, in
 #define MOUSE_DOWN (MOUSE_LDOWN | MOUSE_RDOWN | UI_MOUSE_LDOUBLE)
 #define MOUSE_UP   (MOUSE_LUP | MOUSE_RUP)
 #define MOUSE_LEFT (MOUSE_LDOWN | UI_MOUSE_LDOUBLE)
+#define MOUSE_WHEEL (MOUSE_WHEELUP | MOUSE_WHEELDN)
 
 #define STATUS_X      4
 #define STATUS_Y      1
@@ -459,7 +460,14 @@ uchar slider_handler(uiEvent *ev, uchar butid) {
         }
         break;
     case UI_EVENT_MOUSE:
-        st->sliderpos = mev->pos.x - BR(butid).ul.x;
+        if (mev->action & MOUSE_WHEELUP) {
+            st->sliderpos = st->sliderpos <= 5 ? 0 : st->sliderpos - 5;
+        } else if (mev->action & MOUSE_WHEELDN) {
+            uchar max = BR(butid).lr.x - BR(butid).ul.x - 3;
+            st->sliderpos = lg_min(st->sliderpos + 5, max);
+        } else {
+            st->sliderpos = mev->pos.x - BR(butid).ul.x;
+        }
         slider_deal(butid, TRUE);
         draw_button(butid);
         return TRUE;
@@ -990,7 +998,7 @@ uchar opanel_mouse_handler(uiEvent *ev, LGRegion *r, void *user_data) {
 
     if (!ev->type && (UI_EVENT_MOUSE | UI_EVENT_MOUSE_MOVE))
         return FALSE;
-    if (ev->type == UI_EVENT_MOUSE && !(ev->subtype & (MOUSE_DOWN | MOUSE_UP)))
+    if (ev->type == UI_EVENT_MOUSE && !(ev->subtype & (MOUSE_DOWN | MOUSE_UP | MOUSE_WHEEL)))
         return FALSE;
 
     mev.pos.x -= inventory_region->r->ul.x;

--- a/src/Libraries/INPUT/Source/mouse.h
+++ b/src/Libraries/INPUT/Source/mouse.h
@@ -61,17 +61,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "lg.h"
 #include "error.h"
 #include <stdbool.h>
+#include <stdint.h>
 //#include <Carbon/Carbon.h>
 
 typedef struct _mouse_event
 {
    short x;    				// position
    short y;
-   uchar type; 				// Event mask, bits defined below
+   uint16_t type;			// Event mask, bits defined below
    ulong timestamp;
    uchar buttons;
    uchar modifiers;			// Added for Mac version
-   char pad[5];  			// pad to sixteen bytes
+   char pad[4];  			// pad to sixteen bytes
 } mouse_event;
 
 #define MOUSE_MOTION    1	// Event mask bits
@@ -81,6 +82,9 @@ typedef struct _mouse_event
 #define MOUSE_RUP      16
 #define MOUSE_CDOWN    32
 #define MOUSE_CUP      64
+// bits 7..9 are used for double click events, see UI/Source/event.h
+#define MOUSE_WHEELUP (1 << 10)
+#define MOUSE_WHEELDN (1 << 11)
 
 
 // Mask of events that are allowed into the queue. 

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -365,7 +365,16 @@ void pump_events(void)
 				addMouseEvent(&mouseEvent);
 				break;
 			}
-
+			case SDL_MOUSEWHEEL:
+				if (ev.wheel.y != 0) {
+					mouse_event mouseEvent = {0};
+					mouseEvent.type = ev.wheel.y < 0 ? MOUSE_WHEELDN : MOUSE_WHEELUP;
+					mouseEvent.x = latestMouseEvent.x;
+					mouseEvent.y = latestMouseEvent.y;
+					mouseEvent.timestamp = mouse_get_time();
+					addMouseEvent(&mouseEvent);
+				}
+				break;
 			// TODO: maybe handle other events as well..
 		}
 	}


### PR DESCRIPTION
Handle mouse wheel events in the following places:
 - 3D view: cycle weapons
 - Map (MFD or full): zoom in/out
 - Sliders in options menu