### PR TITLE
Fix crash using broken surgery machine

### DIFF
--- a/src/GameSrc/objuse.c
+++ b/src/GameSrc/objuse.c
@@ -1047,8 +1047,8 @@ uchar object_use(ObjID id, uchar in_inv, ObjID cursor_obj) {
                 do_multi_stuff(pbigs->data2 >> 16);
                 play_digi_fx_obj(SFX_SURGERY_MACHINE, 1, id);
             }
-            retval = TRUE;
-            break;
+            // return here to prevent 'data1' from being interpreted as object IDs below
+            return TRUE;
 
         case CONTPAN_TRIPLE:
         case CONTPED_TRIPLE:


### PR DESCRIPTION
Work around a game data inconsistency: Surgical machines use the 'data1'
field as a conditional defining when the machine will work, and which
message is displayed if it doesn't. However, they also have the 'OBJUSE'
class flag, causing 'data1' to be interpreted as two related object
references.

Leave the object_use() function after handling the surgery machine
logic to avoid referencing invalid object IDs.

Fixes #89