### PR TITLE
Change RndRange() function to include both limits

### DIFF
--- a/src/Libraries/RND/Source/rnd.c
+++ b/src/Libraries/RND/Source/rnd.c
@@ -170,7 +170,7 @@ ulong asm high_umpy(ulong a, ulong b)
 long RndRange(RndStream *prs, long low, long high)
 {
 	// HAX HAX HAX should use this library instead of using the std lib random
-	return (rand() % (high - low)) + low;
+	return (rand() % (high - low + 1)) + low;
 }
 
 //	----------------------------------------------------------------


### PR DESCRIPTION
The RndRange() function should return a random integer number between
low and high inclusive. When low and high are equal, it must return
that value (instead of crashing with an arithmetic exception). This
commit fixes a regression from 5ce973d0.

Fixes #93