### PR TITLE
First Appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+# Despite its name, this image actually contains all sorts of non-VC goodies
+# https://www.appveyor.com/docs/build-environment/ for all the details
+image: Visual Studio 2015
+
+# appveyor-config can, of course, be removed once the branch is merged to master
+branches:
+  only:
+    - master
+    - appveyor-config
+
+# This is necessary because Appveyor creates a tag for artifacts it releases
+# -- so without this we'd create releases forever
+skip_tags: true    
+
+# Tell build_windows.sh that we're building for Appveyor
+environment:
+  APPVEYOR: TRUE
+    
+cache:
+  - build_ext  # uncache this if external deps change (eg. SDL_mixer 2.0.3 gets released)
+
+# Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
+#         So we create a symlink to the real Git, remove it from PATH and add our own.
+# Step 2: We need to use our own make.exe to build stuff, so we add that
+# Step 3: We tell build_windows.sh to create an Appveyor batch file. 
+#         There's actually an "environment" option that I should test to see if APPVEYOR=TRUE could reside there
+# Step 4: Do the actual building
+
+build_script:
+  - mklink /D c:\git "C:\Program Files\Git"
+  - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
+  - set PATH=c:\git\usr\bin;%PATH%;C:\MinGW\bin
+  - copy windows\make.exe \git\usr\bin
+  - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
+  - sh build_windows.sh
+  - build.bat
+
+test: off
+
+# Once building is done, we gather all the necessary DLL files and build our ZIP file.
+
+after_build:
+  - copy c:\mingw\bin\libgcc*.dll .
+  - copy c:\git\mingw64\bin\libstd*.dll .
+  - copy build_ext\built_sdl\bin\SDL*.dll .
+  - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
+  - 7z a systemshock.zip systemshock.exe *.dll 
+
+artifacts:
+  - path: systemshock.zip
+    name: Shockolate
+
+# FIXME: Replace the auth_token with your own
+    
+deploy:
+  - provider: GitHub
+    release: Shockolate-v$(appveyor_build_version)
+    description: 'Latest master branch build of Shockolate for Windows'
+    artifact: systemshock.zip
+    auth_token:
+      secure: 4oa2yc5W2R7oqYQfqkQnqi2yl0v5tSeh58GS+su7tsAXMaM77BeWhSDs+p7T4cWy

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
-@REM Initial build.bat, no changes needed if you already have CMake in PATH
+@REM Initial build.bat for Appveyor
 
-cmake -G "MinGW Makefiles" .
-mingw32-make systemshock
+cmake -G "Unix Makefiles" .
+make systemshock

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -17,7 +17,7 @@ function build_sdl {
 	tar xvf SDL2-${SDL_version}.tar.gz
 	pushd SDL2-${SDL_version}
 
-	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=${install_dir}/built_sdl
+	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" --host=i686-w64-mingw32 --prefix=${install_dir}/built_sdl
 	remove_mwindows
 	make
 	make install
@@ -29,7 +29,8 @@ function build_sdl_mixer {
 	git clone https://github.com/SDL-mirror/SDL_mixer.git
 	pushd SDL_mixer
 
-	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=${install_dir}/built_sdl_mixer
+	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" --host=i686-w64-mingw32 --disable-sdltest --with-sdl-prefix=${install_dir}/built_sdl --prefix=${install_dir}/built_sdl_mixer 
+	
 	remove_mwindows
 	make
 	make install
@@ -71,13 +72,20 @@ fi
 
 # Back to the root directory, copy SDL DLL files for the executable
 cd ..
-cp /usr/local/bin/SDL*.dll .
+cp build_ext/built_sdl/bin/SDL*.dll .
+cp build_ext/built_sdl_mixer/bin/SDL*.dll .
 
 # Set up build.bat
-# TODO: conditional on whether CMake was downloaded
-echo "@echo off
-set PATH=%PATH%;${CMAKE_ROOT}
-cmake -G \"MinGW Makefiles\" .
-mingw32-make systemshock" >build.bat
+if [[ -z "${APPVEYOR}" ]]; then
+	echo "Normal build"
+	echo "@echo off
+	set PATH=%PATH%;${CMAKE_ROOT}
+	cmake -G \"MinGW Makefiles\" .
+	mingw32-make systemshock" >build.bat
+else
+	echo "Appveyor"
+	echo "cmake -G \"Unix Makefiles\" . 
+	make systemshock" >build.bat
+fi
 
 echo "Our work here is done. Run BUILD.BAT in a Windows shell to build the actual source."


### PR DESCRIPTION
Relates to https://github.com/Interrupt/systemshock/issues/51.

Necessary steps after merging:
1. Create an AppVeyor account and link it to GitHub, set up this project for AppVeyor
2. Create an auth token for the project at https://github.com/settings/tokens with repo permissions
3. Encrypt the auth token value using https://ci.appveyor.com/tools/encrypt
4. Replace the auth token value in `appveyor.yml` with the encrypted value.

Optional, but nice, steps:
5. Remove `appveyor-config` from `branches` list in `appveyor.yml`
6. Opt out of global email notifications at https://ci.appveyor.com/notifications

There's probably a lot of room for improvement here; this is intentionally a bare-bones setup. Setting up tagged releases (either instead of, or in addition to, master commits) would be an obvious next step. The appearance of the releases themselves is also very minimal.