### PR TITLE
Add deploy section to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 language: c
 
-sudo: false
-
 notifications:
   email: false
 
-os:
-  - linux
-  - osx
+env:
+  - PACKAGE_NAME="shockolate-$TRAVIS_OS_NAME.tgz"
 
-compiler:
-  - clang
-  - gcc
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: osx
+      compiler: clang
+    - os: osx
+      compiler: gcc
 
 addons:
   apt:
@@ -24,6 +28,25 @@ addons:
       - g++-multilib
 
 script:
-  - ./build_deps.sh
+  - sudo ./osx-linux/install_32bit_sdl.sh
   - cmake .
   - make systemshock
+
+before_deploy:
+  - mkdir -p shockolate
+  - cp systemshock shockolate
+  - cp osx-linux/install_32bit_sdl.sh shockolate
+  - cp osx-linux/readme_osx_linux.md shockolate
+  - tar zcfv $PACKAGE_NAME shockolate
+  - rm -r shockolate
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  overwrite: true
+  api_key:
+    secure: "a39g3rXcx7oTVTXZe8xi2X4I+7iDwSz6MtvwRF026fb8/26UGbf/1VPC+vNTMhUwZ/QEfmzcTY7mE5qJfnEYjssomAwtJj9C+QrJ8SULC3bEBFh6KV9j2twcleZOmM/p9vK1ksTqIE7jraA4eEqgUKsVoneKruid1WtWl947qdeJLs2RCSBM/czsDfRUssjNHlgGOn//Tx7XWFenUtGe2qUzPrGBm/BOpgd9Q9iLUb77PpEaJUdB/9yNLY0i6KxF10Dvjnpe4bQ9C5jj4H++8o4tW/NJXjyY3n1/FZ1w4DXd82RybLnh8QUY/PUHvZmJYkY/0QMKpiInAXGxhAEuVSLC0BueuERoCSB6Hj9513tDiPBQG+DFiF/C2YeKsWt24huDRDldI+saCHUvMamg7RuVrAIZWFdalCQYraMbxW/z2pkGvm5ZUEiT7l/lGtTEg/fHwmS+hh9ANk/R9meKUiwzVp88Lf3exqinEVth20ddydOTQOOuYlTzQSd4fyL19frRpWB0vArblgX4oklHjybAWmAfy7pUYHGxwuipzj8Z51FOk6BQQgeZVzLu2SPRuoPjdzW9iyUfQOcCoVANRF6rxSmcDbscw3BIS3kUrRM7eUIwLGDTq/nyIaNZwsQeH/YzsXQPCCpieb9MrrGl2jhQwK0QyukCFY9HqiCcJWA="
+  file: "$PACKAGE_NAME"
+  on:
+    tags: true
+    repo: Laastine/systemshock

--- a/osx-linux/install_32bit_sdl.sh
+++ b/osx-linux/install_32bit_sdl.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SDL_version=2.0.8
+
+function build_sdl {
+	curl -O https://www.libsdl.org/release/SDL2-${SDL_version}.tar.gz
+	tar xvf SDL2-${SDL_version}.tar.gz
+	pushd SDL2-${SDL_version}
+
+	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32"
+	make
+	make install
+
+	popd
+}
+
+function build_sdl_mixer {
+	git clone --depth 10 https://github.com/SDL-mirror/SDL_mixer.git
+	pushd SDL_mixer
+	git checkout -b 23-05-2018 7cad09d
+
+	export SDL2_CONFIG="/usr/local/bin/sdl2-config"
+	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32"
+	make
+	make install
+
+	popd
+}
+
+build_sdl
+build_sdl_mixer
+
+# Clean up download artifacts
+rm SDL2-${SDL_version}.tar.gz
+rm -fr SDL2-${SDL_version}
+rm -fr SDL_mixer

--- a/osx-linux/readme_osx_linux.md
+++ b/osx-linux/readme_osx_linux.md
@@ -1,0 +1,7 @@
+# Shockolate - Portable systemshock
+============
+
+1. Copy res folder of original systemshock to this directory
+2. Shockolate depends on 32bit SDL2. Install 32-bit SDL2 and SDL2_mixer by running `./install_32bit_sdl.sh`.
+Linux needs sudo for this script. Script compiles and installs both libraries under `/usr/local/`, so make sure you know what you are doing.
+3. Run shockolate `./systemshock`


### PR DESCRIPTION
Regarding issue the #51 

I made deploy script for Travis CI. Deploy produces stand-alone executable, end user readme and SDL install script. SDL install script installs 32bit SDL2 and SDL2_mixer under user's `/usr/local`. I didn't find any public sites which provides precompiled version of 32bit SDL2 so I had to make custom install script for it. SDL install script is also pretty naive and it doesn't succeed for example if required C-libraries or C-compiler aren't installed.
There's also small `readme_osx_linux.md` for linux/osx end users for getting started.

MacOS version works fine, but I didn't get Linux version running with Virtualbox. I guess it's because of Ubuntu's display drivers or virtualbox settings. Maybe some one can verify does Linux version works on real hardware. I also had to remove Linux clang build from Travis CI, because of weird Travis error when installing SDL libraries to `/usr/local`.

Steps to merge this PR:
1. Install travis cli https://github.com/travis-ci/travis.rb#installation
2. Generate personal github access token: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
3. Encrypt private key for travis config file 
`travis encrypt 'INSERT-TOKEN-HERE' -r Interrupt/systemshock` with travis cli
4. Paste encrypt output to .travis.yml to 
```
api_key:
  secure: PASTE-ENCRYPTED-TOKEN-HERE
```
5. Update `repo: Laastine/systemshock` -> `repo: Interrupt/systemshock`
6. Make new git tag and push tag to remote. Travis should build binaries to https://github.com/Interrupt/systemshock/releases

Result should like: https://github.com/Laastine/systemshock/releases