### PR TITLE
Playing back audiologs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Join our Discord to follow along with development: https://discord.gg/m45xPan
   - SDL_Mixer can't play the multi track XMI midi files, need to find another solution for those
   - There is basic midi music support if there are .mid files in `/res/music/` like `thm0.mid`.
     Try this [example music pack made of Chicajo midi's](https://drive.google.com/open?id=18KhiHpmPHGuTedMCPifnox2DWLd2GnCW)
-- Video Files / Audiologs
+- Video Files
   - Need to revive the old movie rendering code in AFile
 
 Downloads

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -11,7 +11,7 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-A
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -56,7 +56,7 @@ uchar audiolog_cancel_func(short, ulong, void *);
 int curr_alog = -1;
 int alog_handle = -1;
 int alog_fn = -1;
-uchar audiolog_setting = 2;
+uchar audiolog_setting = 1;
 //Movie alog = NULL;
 
 Uint8 *alog_buffer = NULL;

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -75,7 +75,7 @@ snd_digi_parms *sdp = NULL;
 extern uchar curr_vol_lev;
 extern void MacTuneUpdateVolume(void);
 
-#define ALOG_MUSIC_DUCK  30
+#define ALOG_MUSIC_DUCK  0.6
 
 //-------------------------------------------------------------
 //  Sorry excuse for a function.
@@ -209,7 +209,7 @@ errtype audiolog_play(int email_id) {
     // Duck the music
     if (music_on) {
         curr_vol_lev = QVAR_TO_VOLUME(QUESTVAR_GET(MUSIC_VOLUME_QVAR));
-        curr_vol_lev = lg_max(0,curr_vol_lev - ALOG_MUSIC_DUCK);
+        curr_vol_lev = curr_vol_lev * ALOG_MUSIC_DUCK;
         MacTuneUpdateVolume();
     }
 

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -123,6 +123,7 @@ errtype audiolog_play(int email_id) {
     if (email_id > (AUDIOLOG_BARK_BASE_ID - AUDIOLOG_BASE_ID)) {
         new_alog_fn = ResOpenFile(bark_files[0]);
     } else {
+        //FIXME: Where are the english audiologs hiding? I don't have a citalog.res file...
         new_alog_fn = ResOpenFile(alog_files[1]);
     }
 

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -55,7 +55,7 @@ uchar audiolog_cancel_func(short, ulong, void *);
 //-------------------
 int curr_alog = -1;
 int alog_handle = -1;
-// int 		alog_fn = -1;
+int alog_fn = -1;
 uchar audiolog_setting = 2;
 //Movie alog = NULL;
 
@@ -140,7 +140,7 @@ errtype audiolog_play(int email_id) {
         end_wait();
         return (ERR_FREAD);
     }
-    // alog_fn = new_alog_fn;
+    alog_fn = new_alog_fn;
 
     palog = malloc(sizeof(Afile));
     if (AfilePrepareRes(AUDIOLOG_BASE_ID + email_id, palog) < 0) {
@@ -201,8 +201,6 @@ errtype audiolog_play(int email_id) {
 
     end_wait();
 
-    ResCloseFile(new_alog_fn);
-
     // bureaucracy
     curr_alog = email_id;
 
@@ -235,11 +233,12 @@ void audiolog_stop() {
         DisposeMovie(alog);
     }
     */
-    //	if (alog_fn >= 0)
-    //	{
-    //		ResCloseFile(alog_fn);
-    //		alog_fn = -1;
-    //	}
+
+    if (alog_fn >= 0)
+    {
+        ResCloseFile(alog_fn);
+        alog_fn = -1;
+    }
 
     // Restore music volume
     if (music_on) {

--- a/src/GameSrc/audiolog.c
+++ b/src/GameSrc/audiolog.c
@@ -156,7 +156,7 @@ errtype audiolog_play(int email_id) {
     // Need to convert the movie's audio format to ours
     // FIXME: Might want to use SDL_AudioStream to do this on the fly
     SDL_AudioCVT cvt;
-    SDL_BuildAudioCVT(&cvt, AUDIO_U8, 1, fix_int(palog->a.sampleRate), MIX_DEFAULT_FORMAT, 2, 44100);
+    SDL_BuildAudioCVT(&cvt, AUDIO_U8, 1, fix_int(palog->a.sampleRate), MIX_DEFAULT_FORMAT, 2, MIX_DEFAULT_FREQUENCY);
     cvt.len = audio_length;  // 1024 stereo float32 sample frames.
     cvt.buf = (Uint8 *) SDL_malloc(cvt.len * cvt.len_mult);
 

--- a/src/Libraries/AFILE/Source/movie.c
+++ b/src/Libraries/AFILE/Source/movie.c
@@ -34,8 +34,7 @@ int32_t AfilePrepareRes(Id id, Afile *afile) {
     fwrite(ptr, ResSize(id), 1, temp_file);
     fseek(temp_file, 0, 0);
 
-    //ResUnlock(id);
-    free(ptr);
+    ResUnlock(id);
 
     int32_t error = AfileOpen(afile, temp_file, AFILE_MOV);
 

--- a/src/Libraries/SND/Source/lgsndx.h
+++ b/src/Libraries/SND/Source/lgsndx.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define __LGSNDX_H
 
 #include <Carbon/Carbon.h>
+#include <SDL_mixer.h>
 
 //#include <QuickTimeComponents.h>
 //#include <Sound.h>
@@ -109,6 +110,7 @@ int   snd_start_midi(void);
 int   snd_stop_midi(void);
 
 int   snd_sample_play(int snd_ref, int len, uchar *smp, struct snd_digi_parms *dprm);
+int   snd_alog_play(int snd_ref, int len, Uint8 *smp, struct snd_digi_parms *dprm);
 void  snd_end_sample(int hnd_id);
 bool  snd_sample_playing(int hnd_id);
 struct snd_digi_parms *snd_sample_parms(int hnd_id);

--- a/src/Libraries/SND/Source/lgsndx.h
+++ b/src/Libraries/SND/Source/lgsndx.h
@@ -150,7 +150,7 @@ void snd_release_current_theme(void);
 //--------------------------
 //	Size/scale defines
 //--------------------------
-#define SND_MAX_SAMPLES		8			// For Mac version.
+#define SND_MAX_SAMPLES		12			// For Mac version.
 #define SND_MAX_SEQUENCES 	8			//¥¥¥ Can I really handle this many?
 
 //--------------------------

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -70,7 +70,7 @@ int snd_alog_play(int snd_ref, int len, Uint8 *smp, struct snd_digi_parms *dprm)
 		return ERR_NOEFFECT;
 	}
 
-	if (samples_by_channel[channel])
+	if (samples_by_channel[channel] && samples_by_channel[channel] != sample)
 		Mix_FreeChunk(samples_by_channel[channel]);
 
 	samples_by_channel[channel] = sample;

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -71,7 +71,7 @@ int snd_alog_play(int snd_ref, int len, Uint8 *smp, struct snd_digi_parms *dprm)
 		return ERR_NOEFFECT;
 	}
 
-	int channel = Mix_PlayChannel(0, playing_audiolog_sample, 0);
+	int channel = Mix_PlayChannel(-1, playing_audiolog_sample, 0);
 	if (channel < 0) {
 		DEBUG("%s: Failed to play sample", __FUNCTION__);
 		Mix_FreeChunk(playing_audiolog_sample);

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -53,6 +53,33 @@ int snd_sample_play(int snd_ref, int len, uchar *smp, struct snd_digi_parms *dpr
 	return channel;
 }
 
+int snd_alog_play(int snd_ref, int len, Uint8 *smp, struct snd_digi_parms *dprm) {
+
+	// Play one of the Audiolog sounds
+
+	Mix_Chunk *sample = Mix_QuickLoad_RAW(smp, len);
+	if (sample == NULL) {
+		DEBUG("%s: Failed to load sample", __FUNCTION__);
+		return ERR_NOEFFECT;
+	}
+
+	int channel = Mix_PlayChannel(0, sample, 0);
+	if (channel < 0) {
+		DEBUG("%s: Failed to play sample", __FUNCTION__);
+		Mix_FreeChunk(sample);
+		return ERR_NOEFFECT;
+	}
+
+	if (samples_by_channel[channel])
+		Mix_FreeChunk(samples_by_channel[channel]);
+
+	samples_by_channel[channel] = sample;
+	digi_parms_by_channel[channel] = *dprm;
+	snd_sample_reload_parms(&digi_parms_by_channel[channel]);
+
+	return channel;
+}
+
 void snd_end_sample(int hnd_id) {
 	Mix_HaltChannel(hnd_id);
 	if (samples_by_channel[hnd_id]) {
@@ -127,6 +154,7 @@ int MacTuneLoadTheme(char* theme_base, int themeID) {
 
 int snd_start_digital(void) { return OK; }
 int snd_sample_play(int snd_ref, int len, uchar *smp, struct snd_digi_parms *dprm) { return OK; }
+int snd_alog_play(int snd_ref, int len, uchar *smp, struct snd_digi_parms *dprm) { return OK; }
 void snd_end_sample(int hnd_id);
 int MacTuneLoadTheme(char* theme_base, int themeID) { return OK; }
 

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -17,7 +17,7 @@ int snd_start_digital(void) {
 		ERROR("%s: Init failed", __FUNCTION__);
 	}
 
-	if(Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) < 0) {
+	if(Mix_OpenAudio(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, 2, 1024) < 0) {
 		ERROR("%s: Couldn't open audio device", __FUNCTION__);
 	}
 


### PR DESCRIPTION
This plays back audiologs now, we might want to use SDL_AudioStream to do this instead to start playing the audiolog without having to load the whole thing though.