### PR TITLE
[WIP][IntelliSense]Visual Studio & VS Code config

### DIFF
--- a/.vs/VSWorkspaceState.json
+++ b/.vs/VSWorkspaceState.json
@@ -1,0 +1,9 @@
+{
+  "ExpandedNodes": [
+    "",
+    "\\src",
+    "\\src\\MacSrc"
+  ],
+  "SelectedNode": "\\src\\MacSrc\\Shock.c",
+  "PreviewInSolutionExplorer": false
+}

--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -9,7 +9,7 @@
       "cwd": "${workspaceRoot}\\build\\x86-Debug",
       "program": "${debugInfo.target}\\build\\x86-Debug\\systemshock.exe",
       "MIMode": "gdb",
-      "miDebuggerPath": "${env.MINGW_PREFIX}\\bin\\gdb.exe",
+      "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe",
       "externalConsole": true
     }
     

--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "cppdbg",
+      "name": "SShock",
+      "project": "",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}\\build\\x86-Debug\\systemshock.exe",
+      "MIMode": "gdb",
+      "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe",
+      "externalConsole": true
+    }
+  ]
+}

--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -4,13 +4,14 @@
   "configurations": [
     {
       "type": "cppdbg",
-      "name": "SShock",
+      "name": "System Shock",
       "project": "",
-      "cwd": "${workspaceRoot}",
-      "program": "${workspaceRoot}\\build\\x86-Debug\\systemshock.exe",
+      "cwd": "${workspaceRoot}\\build\\x86-Debug",
+      "program": "${debugInfo.target}\\build\\x86-Debug\\systemshock.exe",
       "MIMode": "gdb",
-      "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe",
+      "miDebuggerPath": "${env.MINGW_PREFIX}\\bin\\gdb.exe",
       "externalConsole": true
     }
+    
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/systemshock.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build",
+            "environment": [],
+            "externalConsole": true,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:/MinGW/bin/gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cmake.configureOnOpen": true,
+    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools"
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -9,16 +9,16 @@
       "buildRoot": "${workspaceRoot}\\build\\${name}",
       "installRoot": "${workspaceRoot}\\build\\${name}",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "-v",
+      "buildCommandArgs": "-v -d stats",
       "ctestCommandArgs": "",
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
+          "value": "C:\\MinGW\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
+          "value": "C:\\MinGW\\bin\\g++.exe"
         }
       ]
     },
@@ -35,11 +35,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
+          "value": "C:\\MinGW\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
+          "value": "C:\\MinGW\\bin\\g++.exe"
         }
       ]
     },
@@ -53,14 +53,14 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-      "variables": [
+       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
+          "value": "C:\\MinGW\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
+          "value": "C:\\MinGW\\bin\\g++.exe"
         }
       ]
     },
@@ -74,14 +74,14 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-      "variables": [
+       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
+          "value": "C:\\MinGW\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
+          "value": "C:\\MinGW\\bin\\g++.exe"
         }
       ]
     },

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,131 @@
+{
+  // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+  "configurations": [
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "C:/MinGW/bin/gcc.exe"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "C:/MinGW/bin/g++.exe"
+        }
+      ]
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "C:/MinGW/bin/gcc.exe"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "C:/MinGW/bin/g++.exe"
+        }
+      ]
+    },
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "C:/MinGW/bin/gcc.exe"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "C:/MinGW/bin/g++.exe"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${workspaceRoot}\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "C:/MinGW/bin/gcc.exe"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "C:/MinGW/bin/g++.exe"
+        }
+      ]
+    },
+    {
+      "name": "Linux-Debug",
+      "generator": "Unix Makefiles",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "configurationType": "Debug",
+      "remoteCMakeListsRoot": "/var/tmp/src/${workspaceHash}/${name}",
+      "cmakeExecutable": "/usr/local/bin/cmake",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "remoteBuildRoot": "/var/tmp/build/${workspaceHash}/build/${name}",
+      "remoteInstallRoot": "/var/tmp/build/${workspaceHash}/install/${name}",
+      "remoteCopySources": true,
+      "remoteCopySourcesOutputVerbosity": "Normal",
+      "remoteCopySourcesConcurrentCopies": "10",
+      "remoteCopySourcesMethod": "rsync",
+      "remoteCopyBuildOutput": false,
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x64" ]
+    },
+    {
+      "name": "Linux-Release",
+      "generator": "Unix Makefiles",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "configurationType": "Release",
+      "remoteCMakeListsRoot": "/var/tmp/src/${workspaceHash}/${name}",
+      "cmakeExecutable": "/usr/local/bin/cmake",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "remoteBuildRoot": "/var/tmp/build/${workspaceHash}/build/${name}",
+      "remoteInstallRoot": "/var/tmp/build/${workspaceHash}/install/${name}",
+      "remoteCopySources": true,
+      "remoteCopySourcesOutputVerbosity": "Normal",
+      "remoteCopySourcesConcurrentCopies": "10",
+      "remoteCopySourcesMethod": "rsync",
+      "remoteCopyBuildOutput": false,
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x64" ]
+    }
+  ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -14,11 +14,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:\\MinGW\\bin\\gcc.exe"
+          "value": "C:/MinGW/bin/gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:\\MinGW\\bin\\g++.exe"
+          "value": "C:/MinGW/bin/g++.exe"
         }
       ]
     },
@@ -35,11 +35,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:\\MinGW\\bin\\gcc.exe"
+          "value": "C:/MinGW/bin/gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:\\MinGW\\bin\\g++.exe"
+          "value": "C:/MinGW/bin/g++.exe"
         }
       ]
     },
@@ -53,14 +53,14 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-       "variables": [
+      "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:\\MinGW\\bin\\gcc.exe"
+          "value": "C:/MinGW/bin/gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:\\MinGW\\bin\\g++.exe"
+          "value": "C:/MinGW/bin/g++.exe"
         }
       ]
     },
@@ -74,14 +74,14 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-       "variables": [
+      "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:\\MinGW\\bin\\gcc.exe"
+          "value": "C:/MinGW/bin/gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:\\MinGW\\bin\\g++.exe"
+          "value": "C:/MinGW/bin/g++.exe"
         }
       ]
     },

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -14,11 +14,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:/MinGW/bin/gcc.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:/MinGW/bin/g++.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
         }
       ]
     },
@@ -35,11 +35,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:/MinGW/bin/gcc.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:/MinGW/bin/g++.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
         }
       ]
     },
@@ -56,11 +56,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:/MinGW/bin/gcc.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:/MinGW/bin/g++.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
         }
       ]
     },
@@ -77,11 +77,11 @@
       "variables": [
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "C:/MinGW/bin/gcc.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\gcc.exe"
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "C:/MinGW/bin/g++.exe"
+          "value": "${env.MINGW_PREFIX}\\bin\\g++.exe"
         }
       ]
     },


### PR DESCRIPTION
Useful for those that develop in VS or VS Code... for building and debugging and IntelliSense
 by default VS Code it is configured to build in ${workspaceRoot}/build  and VS in ${workspaceRoot}/build/[x86-Debug] 
It looks in the C:/MinGw/bin for gcc, g++ and gdb
Note: needs the CMake Tools for VS Code and Visual C++ tools for CMake
![image](https://user-images.githubusercontent.com/5406932/43018355-147d20d4-8c62-11e8-8227-09751cfeb150.png)
For VS: CMake Menu -> Cache - >Generate 
                                  -> Build copy [res] folder, SDL2.dll and SDL2_mixer.dll
Debug:
![image](https://user-images.githubusercontent.com/5406932/43018653-f9909cb4-8c62-11e8-9fb2-8194d61c79ff.png)
Note2: tested on Visual Studio Community 2017(15.7.5), on W10
