### PR TITLE
Change naming of temporary audio file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ build_ext
 # Save files
 CurrentGame.dat
 savgam*.dat
+
+# Temporary audio files
+.temp.audio

--- a/src/Libraries/AFILE/Source/movie.c
+++ b/src/Libraries/AFILE/Source/movie.c
@@ -24,13 +24,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "res.h"
 
 FILE *temp_file;
+static uint8_t *tempfile_name = ".temp.audio";
 
 int32_t AfilePrepareRes(Id id, Afile *afile) {
 
     uint8_t *ptr = ResLock(id);
 
     // FIXME That's ugly. We need fmemopen() analog.
-    temp_file = tmpfile();
+    temp_file = fopen(tempfile_name, "wb+");
     fwrite(ptr, ResSize(id), 1, temp_file);
     fseek(temp_file, 0, 0);
 


### PR DESCRIPTION
`tmpfile()` produces a file name that Windows can't write into without admin rights