### PR TITLE
Hide Windows console in distributable packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,16 @@ cmake_minimum_required(VERSION 3.1)
 # Required for stdbool.h
 set(CMAKE_C_STANDARD 99)
 
-set(CMAKE_C_FLAGS -m32)
-set(CMAKE_CXX_FLAGS -m32)
+# hide Windows console in distributable packages
+if(DEFINED ENV{APPVEYOR}) 
+	set(CMAKE_C_FLAGS "-m32 -mwindows")
+	set(CMAKE_CXX_FLAGS "-m32 -mwindows")
+endif()
+
+if(NOT DEFINED ENV{APPVEYOR}) 
+	set(CMAKE_C_FLAGS -m32)
+	set(CMAKE_CXX_FLAGS -m32)
+endif()
 
 option(ENABLE_EXAMPLES "Enable example applications" OFF)
 option(ENABLE_DEBUG_BLIT "Enable debugging blitter" OFF)


### PR DESCRIPTION
The `-mwindows` compiler flag hides all console output. 

Removing it from the SDL build clauses in `build_windows.sh` can be omitted because this one covers the SDL debug output as well.