### PR TITLE
Fix leaking elevator semaphores

### DIFF
--- a/src/GameSrc/digifx.c
+++ b/src/GameSrc/digifx.c
@@ -181,7 +181,7 @@ uchar set_sample_pan_gain(snd_digi_parms *sdp) {
         for (i = 0; i < NUM_HEIGHT_SEMAPHORS; i++) {
             h = h_sems[i];
             if ((h.x == (x >> 8)) && (h.y == (y >> 8)) && (h.inuse == 1)) {
-                h.inuse--;
+                h_sems[i].inuse--;
                 return (TRUE);
             }
         }

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -37,7 +37,8 @@ int snd_sample_play(int snd_ref, int len, uchar *smp, struct snd_digi_parms *dpr
 		return ERR_NOEFFECT;
 	}
 
-	int channel = Mix_PlayChannel(-1, sample, 0);
+	int loops = dprm->loops > 0 ? dprm->loops - 1 : -1;
+	int channel = Mix_PlayChannel(-1, sample, loops);
 	if (channel < 0) {
 		DEBUG("%s: Failed to play sample", __FUNCTION__);
 		Mix_FreeChunk(sample);


### PR DESCRIPTION
Elevator semaphores should be freed when the sound sample is stopped. Two bugs prevented this from happening, causing elevator semaphores to leak.

The bridge level uses a lot of elevators in the room with the first force field panel. After this room there was a high likelyhood that all semaphores were busy and no further elevators could be scheduled. These commits should fix #72 for good.