### PR TITLE
Post-OpenGL additions to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ after_build:
   - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
   - copy build_ext\glew-2.1.0\lib\glew32.dll .
   - copy readme\readme-windows.txt readme.txt
-  - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt
+  - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt shaders/
 
 artifacts:
   - path: systemshock-windows.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
 
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)
 # Uncache build_ext if external deps change (eg. SDL_mixer 2.0.3 gets released)
-# cache:
-#  - build_ext  
+cache:
+  - build_ext  
 
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
@@ -38,6 +38,7 @@ after_build:
   - copy c:\mingw\bin\libstd*.dll .
   - copy build_ext\built_sdl\bin\SDL*.dll .
   - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
+  - copy build_ext\glew-2.1.0\lib\glew32.dll .
   - copy readme\readme-windows.txt readme.txt
   - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt
 


### PR DESCRIPTION
This resumes caching of `build_ext` now that GLEW has been built there, and also adds GLEW's DLL file to the distributable package.