### PR TITLE
Implement night sight hardware effect with OpenGL

### DIFF
--- a/shaders/texture.frag
+++ b/shaders/texture.frag
@@ -9,14 +9,23 @@ varying vec2 TexCoords;
 varying float Light;
 
 uniform sampler2D tex;
+uniform bool nightsight;
 
 void main() {
     vec4 t = texture2D(tex, TexCoords);
 
     // Alpha values > 0.5 are emissive
     float alpha = t.a > 0.5 ? 1.0 : t.a * 2.0;
-    float emissive = t.a > 0.5 ? 1.0 : 0.0;
-    float light = max(Light, emissive);
 
-    gl_FragColor = vec4(t.r * light, t.g * light, t.b * light, alpha);
+    if (nightsight) {
+        // approximate the blue tint of palette colors 0xb0..0xbf
+        float gray = 0.40 * t.r + 0.59 * t.g + 0.11 * t.b;
+        float rg = 0.7 * gray;
+        float b = 0.75 * gray + 0.1;
+        gl_FragColor = vec4(rg, rg, b, alpha);
+    } else {
+        float emissive = t.a > 0.5 ? 1.0 : 0.0;
+        float light = max(Light, emissive);
+        gl_FragColor = vec4(t.r * light, t.g * light, t.b * light, alpha);
+    }
 }

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -33,6 +33,7 @@ extern "C" {
     #include "Shock.h"
     #include "faketime.h"
     #include "render.h"
+    #include "wares.h"
 
     extern SDL_Renderer *renderer;
     extern SDL_Palette *sdlPalette;
@@ -54,6 +55,7 @@ struct Shader {
     GLuint shaderProgram;
     GLint uniView;
     GLint uniProj;
+    GLint uniNightSight;
     GLint tcAttrib;
     GLint lightAttrib;
 };
@@ -203,10 +205,12 @@ static int CreateShader(const char *vertexShaderFile, const char *fragmentShader
     glAttachShader(shaderProgram, vertShader);
     glAttachShader(shaderProgram, fragShader);
     glLinkProgram(shaderProgram);
+    glUseProgram(shaderProgram);
 
     outShader->shaderProgram = shaderProgram;
     outShader->uniView = glGetUniformLocation(shaderProgram, "view");
     outShader->uniProj = glGetUniformLocation(shaderProgram, "proj");
+    outShader->uniNightSight = glGetUniformLocation(shaderProgram, "nightsight");
     outShader->tcAttrib = glGetAttribLocation(shaderProgram, "texcoords");
     outShader->lightAttrib = glGetAttribLocation(shaderProgram, "light");
 
@@ -391,6 +395,10 @@ static void updatePalette(SDL_Palette *palette, bool transparent) {
     }
 }
 
+static bool nightsight_active() {
+    return WareActive(player_struct.hardwarez_status[HARDWARE_GOGGLE_INFRARED]);
+}
+
 void opengl_start_frame() {
     SDL_GL_MakeCurrent(window, context);
 
@@ -424,6 +432,8 @@ void opengl_swap_and_restore() {
     GLint tcAttrib = textureShaderProgram.tcAttrib;
     GLint lightAttrib = textureShaderProgram.lightAttrib;
 
+    glUniform1i(textureShaderProgram.uniNightSight, nightsight_active());
+
     glUniformMatrix4fv(textureShaderProgram.uniView, 1, false, IdentityMatrix);
     glUniformMatrix4fv(textureShaderProgram.uniProj, 1, false, IdentityMatrix);
 
@@ -447,6 +457,8 @@ void opengl_swap_and_restore() {
     glEnd();
 
     glFlush();
+
+    glUniform1i(textureShaderProgram.uniNightSight, false);
 
     // check OpenGL error
     GLenum err = glGetError();
@@ -640,19 +652,21 @@ static void set_texture(grs_bitmap *bm) {
 static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttrib) {
 
     // Default, per-vertex lighting
-    float light = vertex.i / 4096.0f;
+    float light = 1.0f - (vertex.i / 4096.0f);
 
-    // Could be a CLUT color instead, use that for lighting
-    if(gr_get_fill_type() == FILL_CLUT) {
+    if (nightsight_active()) {
+        light = 1.0f;
+    } else if (gr_get_fill_type() == FILL_CLUT) {
+        // Could be a CLUT color instead, use that for lighting
         // Ugly hack: We don't get the original light value, so we have to
         // recalculate it from the offset into the global lighting lookup
         // table.
         uchar* clut = (uchar*)gr_get_fill_parm();
-        light = (clut - grd_screen->ltab) / 4096.0f;
+        light = 1.0f - (clut - grd_screen->ltab) / 4096.0f;
     }
 
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
-    glVertexAttrib1f(lightAttrib, 1.0f - light);
+    glVertexAttrib1f(lightAttrib, light);
     glVertex3f(vertex.x / 65536.0f,  vertex.y / 65536.0f, -vertex.z / 65536.0f);
 }
 
@@ -727,7 +741,7 @@ int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
 
     float light = 1.0f;
-    if (ti->flags & TMF_CLUT) {
+    if ((ti->flags & TMF_CLUT) && !nightsight_active()) {
         // Ugly hack: We don't get the original 'i' value, so we have to
         // recalculate it from the offset into the global lighting lookup
         // table.


### PR DESCRIPTION
When the night sight hardware is enabled, let the shader draw everything at full light level and in black and white.

There are a few noticeable differences compared to the software renderer:
- The original effect is more blueish. We could approximate the parameters experimentally, or try to recalculate them from the shading table.
- Software night sight suppresses all palette effects (blinking lights on textures or objects, etc.).
- With software night sight, stars become invisible through structured windows (like the grove ceilings). I think that's a bug, because simple windows continue to show stars.

Fixes #135 