### PR TITLE
Opengl: stars render more like in software mode

### DIFF
--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -26,7 +26,7 @@ int opengl_draw_tmap(int n, g3s_phandle *vp, grs_bitmap *bm);
 int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm);
 int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti);
 int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag);
-int opengl_draw_star(long c, int n_verts, g3s_phandle *p);
+int opengl_draw_star(fix star_x, fix star_y, int c, bool anti_alias);
 void opengl_begin_stars();
 void opengl_end_stars();
 void opengl_set_stencil(int v);
@@ -52,7 +52,7 @@ static int opengl_draw_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) { return 0; 
 static int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) { return 0; }
 static int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) { return 0; }
 static int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag) { return 0; }
-static int opengl_draw_star(long c, int n_verts, g3s_phandle *p) { return 0; }
+static int opengl_draw_star(fix star_x, fix star_y, int c, bool anti_alias) { return 0; }
 static void opengl_begin_stars() {}
 static void opengl_end_stars() {}
 static void opengl_set_stencil(int v) {}


### PR DESCRIPTION
- OpenGL ES 2.0 does't do any filtering of points by default, so this uses a shader to do a similar thing.
- Also makes stars render as crisp pixels in smaller resolutions.
- Fixes the star scaling issue seen in some places, but they still disappear sometimes