### PR TITLE
OpenGL: Rendering sensaround v1 hardware in software mode

### DIFF
--- a/src/GameSrc/view360.c
+++ b/src/GameSrc/view360.c
@@ -52,6 +52,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "cybstrng.h"
 #include "gamescr.h"
 
+#include "OpenGL.h"
+
 extern uchar dirty_inv_canvas;
 
 // -------
@@ -223,6 +225,7 @@ void view360_update_screen_mode() {
 char update_string[30] = "";
 
 void view360_render(void) {
+    opengl_begin_sensaround(player_struct.hardwarez[CPTRIP(SENS_HARD_TRIPLE)]);
     uchar on = FALSE;
     int i;
     if (inventory_page != INV_3DVIEW_PAGE && ACTIVE[MID_CONTEXT]) {
@@ -237,8 +240,10 @@ void view360_render(void) {
             LGRect r;
             char buf[sizeof(update_string)];
             short w, h;
-            if (strlen(update_string) + 1 >= sizeof(update_string))
+            if (strlen(update_string) + 1 >= sizeof(update_string)) {
+                opengl_end_sensaround();
                 return;
+            }
             if (update_string[0] == '\0')
                 get_string(REF_STR_View360Update, buf, sizeof(buf));
             else
@@ -265,6 +270,8 @@ void view360_render(void) {
             ResUnlock(RES_tinyTechFont);
             gr_pop_canvas();
             strcat(update_string, buf);
+
+            opengl_end_sensaround();
             return;
         }
         update_string[0] = '\0';
@@ -276,7 +283,6 @@ void view360_render(void) {
     }
 
     // Render the 360 view scenes.
-
     view360_is_rendering = TRUE;
     for (i = 0; i < NUM_360_CONTEXTS; i++)
         if (ACTIVE[i]) {
@@ -296,6 +302,8 @@ void view360_render(void) {
 
     if (on == !(player_struct.hardwarez_status[HARDWARE_360] & WARE_ON))
         use_ware(WARE_HARD, HARDWARE_360);
+
+    opengl_end_sensaround();
 }
 
 // ------------------

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -94,6 +94,7 @@ static int phys_offset_y;
 static int render_width;
 static int render_height;
 
+static bool opengl_enabled = true;
 static bool palette_dirty = false;
 static bool blend_enabled = true;
 static GLuint bound_texture = -1;
@@ -360,14 +361,13 @@ bool can_use_opengl() {
 }
 
 bool use_opengl() {
-    return can_use_opengl() && gShockPrefs.doUseOpenGL &&
+    return can_use_opengl() && gShockPrefs.doUseOpenGL && opengl_enabled &&
            (_current_loop == GAME_LOOP || _current_loop == FULLSCREEN_LOOP) &&
-           !global_fullmap->cyber &&
-           !(_fr_curflags & (FR_PICKUPM_MASK | FR_HACKCAM_MASK));
+           !global_fullmap->cyber && !(_fr_curflags & (FR_PICKUPM_MASK | FR_HACKCAM_MASK));
 }
 
 bool should_opengl_swap() {
-    return can_use_opengl() && gShockPrefs.doUseOpenGL &&
+    return can_use_opengl() && gShockPrefs.doUseOpenGL && opengl_enabled &&
            (_current_loop == GAME_LOOP || _current_loop == FULLSCREEN_LOOP) &&
            !global_fullmap->cyber;
 }
@@ -890,8 +890,8 @@ int opengl_draw_star(fix star_x, fix star_y, int c, bool anti_alias) {
     y = (y / render_height) * -2.0 + 1.0;
 
     // rescale the color so that it's 0..255, 0 = dark, 255 = light
-    int std_color_base = 208;;
-    int std_color_range = 16;;
+    int std_color_base = 208;
+    int std_color_range = 16;
     int color = (std_color_base + std_color_range - 1 - c);
     color = (255 * color) / (std_color_range + 1);
 
@@ -899,6 +899,17 @@ int opengl_draw_star(fix star_x, fix star_y, int c, bool anti_alias) {
     glVertex3f(x,  y, -0.25f);
 
     return CLIP_NONE;
+}
+
+void opengl_begin_sensaround(uchar version) {
+    if(version == 1) {
+        // Version 1 of the sensaround is old tech, and should render in software mode :D
+        opengl_enabled = FALSE;
+    }
+}
+
+void opengl_end_sensaround() {
+    opengl_enabled = TRUE;
 }
 
 #endif // USE_OPENGL

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -32,6 +32,8 @@ void opengl_end_stars();
 void opengl_set_stencil(int v);
 void opengl_start_frame();
 void opengl_end_frame();
+void opengl_begin_sensaround(uchar version);
+void opengl_end_sensaround();
 
 #else
 
@@ -58,6 +60,8 @@ static void opengl_end_stars() {}
 static void opengl_set_stencil(int v) {}
 static void opengl_start_frame() {}
 static void opengl_end_frame() {}
+static void opengl_begin_sensaround(uchar version) {}
+static void opengl_end_sensaround() {}
 
 #endif
 


### PR DESCRIPTION
This fixes the Sensaround V1 hardware, by rendering just that version in software mode. Sensaround V1 must not be hardware accelerated like the upgrade are :)