### PR TITLE
More efficient OpenGL polygon rendering

### DIFF
--- a/shaders/color.frag
+++ b/shaders/color.frag
@@ -1,11 +1,8 @@
 #version 110
 
-varying vec2 TexCoords;
+varying vec4 Color;
 varying float Light;
 
-uniform sampler2D tex;
-
 void main() {
-    vec4 t = texture2D(tex, TexCoords);
-    gl_FragColor = vec4(t.r * Light, t.g * Light, t.b * Light, t.a);
+    gl_FragColor = vec4(Color.r * Light, Color.g * Light, Color.b * Light, Color.a);
 }

--- a/shaders/main.vert
+++ b/shaders/main.vert
@@ -2,9 +2,11 @@
 
 attribute vec2 texcoords;
 attribute float light;
+attribute vec4 color;
 
 varying vec2 TexCoords;
 varying float Light;
+varying vec4 Color;
 
 uniform mat4 view;
 uniform mat4 proj;
@@ -12,5 +14,6 @@ uniform mat4 proj;
 void main() {
     TexCoords = texcoords;
     Light = light;
+    Color = color;
     gl_Position = proj * view * gl_Vertex;
 }

--- a/shaders/star.frag
+++ b/shaders/star.frag
@@ -1,17 +1,13 @@
 #version 120
 
-varying vec2 TexCoords;
 varying float Light;
 
-uniform sampler2D tex;
-
 void main() {
-    vec4 t = texture2D(tex, gl_PointCoord);
     vec2 mid = vec2(0.5, 0.5) - gl_PointCoord;
 
     float dist = 0.5 - length(mid);
     dist *= 3.0;
     dist = min(dist, 1.0);
 
-    gl_FragColor = vec4(dist * t.r * Light, dist * t.g * Light, dist * t.b * Light, t.a);
+    gl_FragColor = vec4(dist * Light, dist * Light, dist * Light, 1.0);
 }


### PR DESCRIPTION
Instead of creating an 1x1 pixel dummy texture for each polygon, simply
pass the color as a vertex attribute to the shader program.