### PR TITLE
Fix segfault before splash fade out

### DIFF
--- a/src/GameSrc/tools.c
+++ b/src/GameSrc/tools.c
@@ -235,9 +235,9 @@ errtype draw_full_res_bm(Ref id, int x, int y, uchar fade_in) {
     f->bm.bits = (uchar *)(f + 1);
     ss_bitmap(&f->bm, x, y); // KLC  ss_bitmap(&f->bm, x, y);
     RefUnlock(id);
-    ResDrop(REFID(id));
     if (fade_in)
         finish_pal_effect(pal_id);
+    ResDrop(REFID(id));
     return (OK);
 }
 


### PR DESCRIPTION
As discussed on Discord, the game segfaults with the following backtrace on my Fedora 28 machine after showing the Origin splash screen:

> 0xf7939dd1 in memcpy () from /lib/libc.so.6 (gdb) bt 
> #0 0xf7939dd1 in memcpy () from /lib/libc.so.6 
> #1 0x080f2d6c in gr_set_pal () 
> #2 0x08128ba1 in palette_advance_effect () 
> #3 0x080b1a5b in finish_pal_effect () #4 0x080c243c in draw_full_res_bm () 
> #5 0x080bbb13 in splash_draw () 
> #6 0x08078f9f in main ()