### PR TITLE
Bugfixes: Erratic mouselook; Terrain elevator nonstop sound; Cutscene audio; Mouselook held obj; Shift key sprint; Cutscene window resize; Gamma slider

### DIFF
--- a/src/GameSrc/Headers/setup.h
+++ b/src/GameSrc/Headers/setup.h
@@ -84,7 +84,7 @@ void go_and_start_the_game_already(void);
 errtype load_that_thar_game(int which_slot);
 
 // Show splash screens
-void splash_draw(void);
+void splash_draw(bool show_splash);
 
 // Globals
 

--- a/src/GameSrc/cutsloop.c
+++ b/src/GameSrc/cutsloop.c
@@ -187,6 +187,7 @@ short play_cutscene(int id, bool show_credits) {
     sdp->vol = 128;
     sdp->pan = 64;
     sdp->snd_ref = 0;
+    sdp->data = NULL;
 
     // Need to convert the movie's audio format to ours
     // FIXME: Might want to use SDL_AudioStream to do this on the fly
@@ -200,11 +201,11 @@ short play_cutscene(int id, bool show_credits) {
 
     // Stop current music
 	MacTuneKillCurrentTheme();
-	
+
 	// Now play the sample
     extern uchar sfx_on;
     if (sfx_on) snd_alog_play(0x0, cvt.len_cvt, cvt.buf, sdp);
-	
+
     // Reset the movie reader
     AfileReadReset(amovie);
 

--- a/src/GameSrc/cutsloop.c
+++ b/src/GameSrc/cutsloop.c
@@ -200,10 +200,11 @@ short play_cutscene(int id, bool show_credits) {
 
     // Stop current music
 	MacTuneKillCurrentTheme();
-
+	
 	// Now play the sample
-    snd_alog_play(0x0, cvt.len_cvt, cvt.buf, sdp);
-
+    extern uchar sfx_on;
+    if (sfx_on) snd_alog_play(0x0, cvt.len_cvt, cvt.buf, sdp);
+	
     // Reset the movie reader
     AfileReadReset(amovie);
 

--- a/src/GameSrc/cutsloop.c
+++ b/src/GameSrc/cutsloop.c
@@ -89,6 +89,8 @@ void cutscene_start() {
 
 	_current_view = &cutscene_root_region;
 	uiSetCurrentSlab(&cutscene_slab);
+
+	uiHideMouse(NULL);
 }
 
 void cutscene_exit() {

--- a/src/GameSrc/cutsloop.c
+++ b/src/GameSrc/cutsloop.c
@@ -77,6 +77,8 @@ uchar cutscene_mouse_handler(uiEvent *ev, LGRegion *r, void *user_data) {
 
 }
 
+void CaptureMouse(bool capture);
+
 void cutscene_start() {
 	DEBUG("Cutscene start");
 
@@ -91,6 +93,8 @@ void cutscene_start() {
 	uiSetCurrentSlab(&cutscene_slab);
 
 	uiHideMouse(NULL);
+
+	CaptureMouse(FALSE);
 }
 
 void cutscene_exit() {

--- a/src/GameSrc/gameloop.c
+++ b/src/GameSrc/gameloop.c
@@ -53,6 +53,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "gr2ss.h"
 #include "game_screen.h"
 
+#include "Prefs.h"
+
 #undef RECT_FILL
 #define RECT_FILL(pr, x1, y1, x2, y2) \
     {                                 \
@@ -200,6 +202,8 @@ void game_loop(void) {
 
         if (pal_fx_on) {
             loopLine(GL | 0x1F, palette_advance_all_fx(*tmd_ticks));
+
+			gamma_dealfunc(gShockPrefs.doGamma);
         }
 
         Spew("gameloop", "destroy_destroyed_objects\n");

--- a/src/GameSrc/hkeyfunc.c
+++ b/src/GameSrc/hkeyfunc.c
@@ -1281,6 +1281,7 @@ uchar pause_game_func(short keycode, ulong context, void *data) {
 
     if (game_paused) {
         redraw_paused = TRUE;
+		snd_kill_all_samples();
         return FALSE;
     }
 

--- a/src/GameSrc/mouselook.c
+++ b/src/GameSrc/mouselook.c
@@ -101,7 +101,7 @@ void mouse_look_physics() {
 }
 
 void center_mouse() {
-    uiHideMouse(NULL);
+//    uiHideMouse(NULL);
 
     short middle_x = (grd_cap->w / 2);
     short middle_y = (grd_cap->h / 2);
@@ -111,9 +111,9 @@ void center_mouse() {
     pump_events();
     mouse_flush();
     uiFlush();
-    uiPopGlobalCursor();
+//    uiPopGlobalCursor();
     // This will show the mouse again
-    uiSetCursor();
+//    uiSetCursor();
 }
 
 void mouse_look_toggle() {

--- a/src/GameSrc/schedule.c
+++ b/src/GameSrc/schedule.c
@@ -110,6 +110,8 @@ int compare_events(void *e1, void *e2) {
 // SUPPORT FUNCTIONS
 // -----------------
 
+void stop_terrain_elevator_sound(short sem);
+
 uchar register_h_event(uchar x, uchar y, uchar floor, char *sem, char *key, uchar no_sfx) {
     int i, fr;
 
@@ -120,6 +122,9 @@ uchar register_h_event(uchar x, uchar y, uchar floor, char *sem, char *key, ucha
         else if (h_sems[i].x == x && h_sems[i].y == y && h_sems[i].floor == floor) {
 
             // conflict.  Take over the old semaphor.
+
+			stop_terrain_elevator_sound(i);
+
             if (h_sems[i].key < MAX_HSEM_KEY)
                 h_sems[i].key++;
             else
@@ -160,7 +165,10 @@ uchar register_h_event(uchar x, uchar y, uchar floor, char *sem, char *key, ucha
 void unregister_h_event(char sem) {
     if (sem < 0 || sem >= NUM_HEIGHT_SEMAPHORS)
         return;
-    h_sems[sem].inuse--;
+
+	stop_terrain_elevator_sound(sem);
+
+	h_sems[sem].inuse = 0;
 }
 
 // --------------

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -1168,6 +1168,8 @@ void pause_for_key(ulong wait_time) {
 void splash_draw(bool show_splash) {
     int pal_file;
 
+	if (!show_splash) return;
+
     // Need to load the splash palette file
 
     INFO("Loading splshpal.res");
@@ -1206,35 +1208,29 @@ void splash_draw(bool show_splash) {
     #endif
 
     uiHideMouse(NULL);
-	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmOriginSplash, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
-	}
 
     // Draw LGS Logo
 
     uiHideMouse(NULL);
-	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmLGSplash, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
-	}
 
     // Draw System Shock title
 
     uiHideMouse(NULL);
-	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmSystemShockTitle, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
-	}
 
     // Original palette
     gr_set_pal(0, 256, ppall);

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -1165,7 +1165,7 @@ void pause_for_key(ulong wait_time) {
     waiting_for_key = false;
 }
 
-void splash_draw() {
+void splash_draw(bool show_splash) {
     int pal_file;
 
     // Need to load the splash palette file
@@ -1206,29 +1206,35 @@ void splash_draw() {
     #endif
 
     uiHideMouse(NULL);
+	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmOriginSplash, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
+	}
 
     // Draw LGS Logo
 
     uiHideMouse(NULL);
+	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmLGSplash, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
+	}
 
     // Draw System Shock title
 
     uiHideMouse(NULL);
+	if (show_splash) {
     draw_full_res_bm(REF_IMG_bmSystemShockTitle, 0, 0, do_fades);
     pause_for_key(500);
 
     if (do_fades)
         palfx_fade_down();
+	}
 
     // Original palette
     gr_set_pal(0, 256, ppall);

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -1818,8 +1818,8 @@ void video_screen_init(void) {
 
     standard_slider_rect(&r, i, 2, 2);
     r.ul.x = r.ul.x + 1;
-    sliderbase = ((r.lr.x - r.ul.x - 1) * ((29 * FIX_UNIT) / 100)) / USHRT_MAX;
-    slider_init(i, REF_STR_OptionsText + 3, sizeof(ushort), TRUE, &player_struct.questvars[GAMMACOR_QVAR], USHRT_MAX,
+    sliderbase = ((r.lr.x - r.ul.x - 1) * 29 / 100);
+    slider_init(i, REF_STR_OptionsText + 3, sizeof(ushort), TRUE, &(gShockPrefs.doGamma), 100,
                 sliderbase, gamma_dealfunc, &r);
 
 #if defined(VFX1_SUPPORT) || defined(CTM_SUPPORT)

--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -94,6 +94,9 @@ void mac_set_mode(void)
 
  void ChangeScreenSize(int width, int height)
  {
+    extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
+    if (gScreenWide == width && gScreenHigh == height) return;
+
     extern SDL_Renderer* renderer;
     extern SDL_Window* window;
 
@@ -130,7 +133,6 @@ void mac_set_mode(void)
 
     SDL_RenderSetLogicalSize(renderer, width, height);
 
-    extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
     gScreenWide = width;
     gScreenHigh = height;
     gActiveWide = width;

--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -98,9 +98,36 @@ void mac_set_mode(void)
     extern SDL_Window* window;
 
     SDL_RenderClear(renderer);
-    
-    SDL_SetWindowSize(window, width, height);
-    SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+
+	SDL_bool grab = SDL_GetWindowGrab(window);
+	if (grab)
+	{
+		SDL_SetWindowGrab(window, SDL_FALSE);
+		SDL_SetWindowResizable(window, SDL_TRUE);
+	}
+
+	extern bool fullscreenActive;
+	if (fullscreenActive)
+	{
+		SDL_DisplayMode dm;
+
+		SDL_GetDesktopDisplayMode(0, &dm);
+		SDL_SetWindowSize(window, dm.w, dm.h + 10); //10 should be height of title bar
+	}
+	else
+	{
+		if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED))
+			SDL_SetWindowSize(window, width, height);
+	}
+
+	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+
+	if (grab)
+	{
+		SDL_SetWindowGrab(window, SDL_TRUE);
+		SDL_SetWindowResizable(window, SDL_FALSE);
+	}
+
     SDL_RenderSetLogicalSize(renderer, width, height);
 
     extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
@@ -108,8 +135,6 @@ void mac_set_mode(void)
     gScreenHigh = height;
     gActiveWide = width;
     gActiveHigh = height;
-
-    // TODO: Fix up the screen sizes in fullscreen mode?
  }
 
 

--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -102,34 +102,11 @@ void mac_set_mode(void)
 
     SDL_RenderClear(renderer);
 
-	SDL_bool grab = SDL_GetWindowGrab(window);
-	if (grab)
-	{
-		SDL_SetWindowGrab(window, SDL_FALSE);
-		SDL_SetWindowResizable(window, SDL_TRUE);
-	}
-
 	extern bool fullscreenActive;
-	if (fullscreenActive)
-	{
-		SDL_DisplayMode dm;
+	SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 
-		SDL_GetDesktopDisplayMode(0, &dm);
-		SDL_SetWindowSize(window, dm.w, dm.h + 10); //10 should be height of title bar
-	}
-	else
-	{
-		if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED))
-			SDL_SetWindowSize(window, width, height);
-	}
-
+	SDL_SetWindowSize(window, width, height);
 	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-
-	if (grab)
-	{
-		SDL_SetWindowGrab(window, SDL_TRUE);
-		SDL_SetWindowResizable(window, SDL_FALSE);
-	}
 
     SDL_RenderSetLogicalSize(renderer, width, height);
 

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -271,6 +271,9 @@ static uchar sdlKeyCodeToSSHOCKkeyCode(SDL_Keycode kc)
 	return KBC_NONE;
 }
 
+static int MouseLookX;
+static int MouseLookY;
+
 void pump_events(void)
 {
 	SDL_Event ev;
@@ -385,6 +388,10 @@ void pump_events(void)
 				mouseEvent.timestamp = mouse_get_time();
 
 				addMouseEvent(&mouseEvent);
+
+				MouseLookX = ev.motion.x; //only update these when mouse actually moves
+				MouseLookY = ev.motion.y;
+
 				break;
 			}
 			case SDL_MOUSEWHEEL:
@@ -602,15 +609,22 @@ errtype mouse_flush(void)
 
 errtype mouse_get_xy(short* x, short* y)
 {
-	*x = latestMouseEvent.x;
-	*y = latestMouseEvent.y;
+	// *x = latestMouseEvent.x;
+	// *y = latestMouseEvent.y;
+
+	*x = MouseLookX; //these only updated when mouse cursor actually moves
+	*y = MouseLookY;
+
 	return OK;
 }
 
 errtype mouse_put_xy(short x, short y)
 {
-	latestMouseEvent.x = x;
+	latestMouseEvent.x = x; //still update these so mouse pointer doesn't jitter
 	latestMouseEvent.y = y;
+
+	MouseLookX = x;
+	MouseLookY = y;
 
 	// scale new mouse coordinates from logical (game resolution) to
 	// physical (SDL window size)

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -334,6 +334,17 @@ void pump_events(void)
 					}
 				}
 
+				//hack to allow pressing shift after move key
+				if (c == 0x38 || c == 0x3C) //left or right shift
+				{
+					int i;
+					for (i=0; i<256; i++) if (sshockKeyStates[i])
+					{
+						if (ev.key.state == SDL_PRESSED) sshockKeyStates[i] |=  KB_MOD_SHIFT;
+						else                             sshockKeyStates[i] &= ~KB_MOD_SHIFT;
+					}
+				}
+
 				break;
 			}
 			case SDL_TEXTINPUT:

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -36,8 +36,29 @@ static bool fullscreenActive = false;
 
 static void toggleFullScreen()
 {
+	// fullscreenActive = !fullscreenActive;
+	// SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+
+	SDL_DisplayMode dm;
+	static int w, h;
+	void CaptureMouse(bool capture);
+
+	CaptureMouse(FALSE);
+	if (fullscreenActive)
+	{
+		SDL_RestoreWindow(window);
+		SDL_SetWindowSize(window, w, h);
+	}
+	else
+	{
+		SDL_GetDesktopDisplayMode(0, &dm);
+		SDL_GetWindowSize(window, &w, &h);
+		SDL_RestoreWindow(window);
+		SDL_SetWindowSize(window, dm.w, dm.h + 10); //10 should be height of title bar
+	}
+	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	fullscreenActive = !fullscreenActive;
-	SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+	CaptureMouse(TRUE);
 }
 
 // current state of the keys, based on the SystemShock/Mac Keycodes (sshockKeyStates[keyCode] has the state for that key)

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -32,18 +32,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern SDL_Window *window;
 extern SDL_Renderer *renderer;
 
-static bool fullscreenActive = false;
+bool fullscreenActive = false;
 
 static void toggleFullScreen()
 {
 	// fullscreenActive = !fullscreenActive;
 	// SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 
-	SDL_DisplayMode dm;
 	static int w, h;
-	void CaptureMouse(bool capture);
 
-	CaptureMouse(FALSE);
+	SDL_bool grab = SDL_GetWindowGrab(window);
+	if (grab)
+	{
+		SDL_SetWindowGrab(window, SDL_FALSE);
+		SDL_SetWindowResizable(window, SDL_TRUE);
+	}
+
 	if (fullscreenActive)
 	{
 		SDL_RestoreWindow(window);
@@ -51,14 +55,23 @@ static void toggleFullScreen()
 	}
 	else
 	{
+		SDL_DisplayMode dm;
+
 		SDL_GetDesktopDisplayMode(0, &dm);
 		SDL_GetWindowSize(window, &w, &h);
 		SDL_RestoreWindow(window);
 		SDL_SetWindowSize(window, dm.w, dm.h + 10); //10 should be height of title bar
 	}
+
 	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+
+	if (grab)
+	{
+		SDL_SetWindowGrab(window, SDL_TRUE);
+		SDL_SetWindowResizable(window, SDL_FALSE);
+	}
+
 	fullscreenActive = !fullscreenActive;
-	CaptureMouse(TRUE);
 }
 
 // current state of the keys, based on the SystemShock/Mac Keycodes (sshockKeyStates[keyCode] has the state for that key)

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -640,12 +640,12 @@ errtype mouse_put_xy(short x, short y)
 
 	if (scale_x >= scale_y) {
 		// physical aspect ratio is wider; black borders left and right
-		int ofs_x = (physical_width - logical_width * scale_y + 1) / 2;
+		int ofs_x = (physical_width - logical_width * scale_y) / 2;
 		x = x * scale_y + ofs_x;
 		y = y * scale_y;
 	} else {
 		// physical aspect ratio is narrower; black borders at top and bottom
-		int ofs_y = (physical_height - logical_height * scale_x + 1) / 2;
+		int ofs_y = (physical_height - logical_height * scale_x) / 2;
 		x = x * scale_x;
 		y = y * scale_x + ofs_y;
 	}

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -338,9 +338,12 @@ void SDLDraw()
 	}
 }
 
+bool MouseCaptured = FALSE;
+
 void CaptureMouse(bool capture)
 {
-	SDL_SetWindowGrab(window, capture && gShockPrefs.goCaptureMouse);
+	MouseCaptured = (capture && gShockPrefs.goCaptureMouse);
 
-	SDL_SetWindowResizable(window, !(capture && gShockPrefs.goCaptureMouse));
+	SDL_SetWindowGrab(window, MouseCaptured);
+	SDL_SetWindowResizable(window, !MouseCaptured);
 }

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -167,10 +167,8 @@ int main(int argc, char** argv)
 
 	// Draw the splash screen
 
-	if(show_splash) {
-		INFO("Showing splash screen");
-		splash_draw();
-	}
+	INFO("Showing splash screen");
+	splash_draw(show_splash);
 
 	// Start in the Main Menu loop
 
@@ -343,5 +341,6 @@ void SDLDraw()
 void CaptureMouse(bool capture)
 {
 	SDL_SetWindowGrab(window, capture && gShockPrefs.goCaptureMouse);
+
 	SDL_SetWindowResizable(window, !(capture && gShockPrefs.goCaptureMouse));
 }

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -343,4 +343,5 @@ void SDLDraw()
 void CaptureMouse(bool capture)
 {
 	SDL_SetWindowGrab(window, capture && gShockPrefs.goCaptureMouse);
+	SDL_SetWindowResizable(window, !(capture && gShockPrefs.goCaptureMouse));
 }


### PR DESCRIPTION
Clicking captured mouse cursor on window resize border (why is this allowed by SDL?) in windowed, non-mouselook mode, then switching to mouselook mode causes mouselook to behave erratically.

When capturing mouse, now also disable window border drag resize. Also added hack to actually keep captured mouse cursor inside client area.

**Edit1:** Added a fix for mouselook drift when clicking. Mouselook now only checks actual mouse move events.

**Edit2:** Added fix for terrain elevator sound not stopping when reversing an already moving terr elevator.

**Edit3:** Don't play cutscene audio if sound is turned off in options. Before this fix, cutscene audio did not stop when skipping cutscene. Also set data member of snd_digi_parms to NULL; otherwise uninitialized.

**Edit4:** Fix for mouselook toggle making held object change to crosshair, while obj still held.

**Edit5:** Hack to allow pressing shift after move key. For example, while holding 'w', repeatedly press and release shift to alternately run and walk.

**Edit6:** Hide mouse cursor during cutscenes. The transparent area around the cursor is not drawing properly anyway.

**Edit7:** Don't change screen size during cutscenes or after exiting full map display, and make changing screen size smarter. Uncapture mouse during cutscenes.

**Edit8:** Fixed gamma slider in options and gamma update in game loop.

**Edit9:** Stop all sound channels when pausing.

**Edit10:** Compensate for difference in brightness between fullscreen and windowed mode. May be platform-specific--tested on Windows.