### PR TITLE
Better handle switching from/to window

### DIFF
--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -102,34 +102,11 @@ void mac_set_mode(void)
 
     SDL_RenderClear(renderer);
 
-	SDL_bool grab = SDL_GetWindowGrab(window);
-	if (grab)
-	{
-		SDL_SetWindowGrab(window, SDL_FALSE);
-		SDL_SetWindowResizable(window, SDL_TRUE);
-	}
-
 	extern bool fullscreenActive;
-	if (fullscreenActive)
-	{
-		SDL_DisplayMode dm;
+	SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 
-		SDL_GetDesktopDisplayMode(0, &dm);
-		SDL_SetWindowSize(window, dm.w, dm.h + 10); //10 should be height of title bar
-	}
-	else
-	{
-		if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED))
-			SDL_SetWindowSize(window, width, height);
-	}
-
+	SDL_SetWindowSize(window, width, height);
 	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-
-	if (grab)
-	{
-		SDL_SetWindowGrab(window, SDL_TRUE);
-		SDL_SetWindowResizable(window, SDL_FALSE);
-	}
 
     SDL_RenderSetLogicalSize(renderer, width, height);
 

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -465,12 +465,11 @@ void pump_events(void)
 					break;
 
 					case SDL_WINDOWEVENT_FOCUS_GAINED:
-						SDL_SetWindowBordered(window, !MouseCaptured);
+						SDL_SetWindowResizable(window, !MouseCaptured);
 						SDL_SetWindowGrab(window, MouseCaptured);
 					break;
 
 					case SDL_WINDOWEVENT_FOCUS_LOST:
-						SDL_SetWindowBordered(window, SDL_TRUE);
 						SDL_SetWindowResizable(window, SDL_TRUE);
 						SDL_SetWindowGrab(window, SDL_FALSE);
 					break;

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -45,10 +45,6 @@ static void toggleFullScreen()
 	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
 	SDL_WarpMouseGlobal(x, y);
-
-	//On Windows fullscreen brightness is higher than windowed, so we compensate; other platforms?
-    float brightness = fullscreenActive ? 0.5 : 1.0;
-    SDL_SetWindowBrightness(window, brightness);
 }
 
 // current state of the keys, based on the SystemShock/Mac Keycodes (sshockKeyStates[keyCode] has the state for that key)

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -426,25 +426,29 @@ void pump_events(void)
 				}
 				break;
 			case SDL_WINDOWEVENT:
-				if (ev.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-					if(can_use_opengl()) {
-						opengl_resize(ev.window.data1, ev.window.data2);
-					}
-				}
-			// TODO: maybe handle other events as well..
+				switch (ev.window.event)
+				{
+					case SDL_WINDOWEVENT_SIZE_CHANGED:
+						if (can_use_opengl()) opengl_resize(ev.window.data1, ev.window.data2);
+					break;
 
-				if (ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
-					SDL_SetWindowBordered(window, !MouseCaptured);
-					SDL_SetWindowGrab(window, MouseCaptured);
-					SDL_ShowCursor(SDL_DISABLE);
-				}
+					case SDL_WINDOWEVENT_MOVED:
+					case SDL_WINDOWEVENT_RESIZED:
+					break;
 
-				if (ev.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
-					SDL_SetWindowBordered(window, SDL_TRUE);
-					SDL_SetWindowGrab(window, SDL_FALSE);
-					SDL_ShowCursor(SDL_ENABLE);
-				}
+					case SDL_WINDOWEVENT_FOCUS_GAINED:
+						SDL_SetWindowBordered(window, !MouseCaptured);
+						SDL_SetWindowGrab(window, MouseCaptured);
+						SDL_ShowCursor(SDL_DISABLE);
+					break;
 
+					case SDL_WINDOWEVENT_FOCUS_LOST:
+						SDL_SetWindowBordered(window, SDL_TRUE);
+						SDL_SetWindowResizable(window, SDL_TRUE);
+						SDL_SetWindowGrab(window, SDL_FALSE);
+						SDL_ShowCursor(SDL_ENABLE);
+					break;
+				}
 			break;
 		}
 	}

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -276,54 +276,43 @@ void KeepMouseCaptured(void)
 
 void pump_events(void)
 {
+	extern bool MouseCaptured;
+
 	KeepMouseCaptured();
 
 	SDL_Event ev;
-	while(SDL_PollEvent(&ev))
+
+	while (SDL_PollEvent(&ev))
 	{
 		switch(ev.type)
 		{
-			case SDL_QUIT:
-				// a bit hacky at this place, but this would allow exiting the game via the window's [x] button
-				exit(0); // TODO: I guess there is a better way.
-				break;
+			case SDL_QUIT: exit(0); break;
 
-
-			// TODO: really also handle key up here? the mac code apparently didn't, but where else do
-			//       kbs_events with .state == KBS_UP come from?
 			case SDL_KEYUP:
 			case SDL_KEYDOWN:
 			{
 				uchar c = sdlKeyCodeToSSHOCKkeyCode(ev.key.keysym.sym);
-				if(c != KBC_NONE)
+
+				if (c != KBC_NONE)
 				{
 					kbs_event keyEvent = { 0 };
 					keyEvent.code = c;
 
-					//printf("ev.key.keysym.sym: %x\n", ev.key.keysym.sym);
-
-					// FIXME: this is hacky, see comment in SDL_TEXTINPUT below..
-					if(ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= '~')
-						keyEvent.ascii = ev.key.keysym.sym;
-					else
-						keyEvent.ascii = 0;
+					if (ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= '~') keyEvent.ascii = ev.key.keysym.sym;
+					else keyEvent.ascii = 0;
 
 					keyEvent.modifiers = 0;
-					Uint16 mod = ev.key.keysym.mod;
-					if(mod & KMOD_CTRL)
-						keyEvent.modifiers |= KB_MOD_CTRL;
-					if(mod & KMOD_SHIFT)
-						keyEvent.modifiers |= KB_MOD_SHIFT;
-					// TODO: what's 0x04 ? windows key?
-					if(mod & KMOD_ALT)
-						keyEvent.modifiers |= KB_MOD_ALT;
 
-					if(ev.key.state == SDL_PRESSED)
+					Uint16 mod = ev.key.keysym.mod;
+
+					if (mod & KMOD_CTRL) keyEvent.modifiers |= KB_MOD_CTRL;
+					if (mod & KMOD_SHIFT) keyEvent.modifiers |= KB_MOD_SHIFT;
+					if (mod & KMOD_ALT) keyEvent.modifiers |= KB_MOD_ALT;
+
+					if (ev.key.state == SDL_PRESSED)
 					{
-						if (ev.key.keysym.sym == SDLK_RETURN && mod & KMOD_ALT) {
-							toggleFullScreen();
-							break;
-						}
+						if (ev.key.keysym.sym == SDLK_RETURN && mod & KMOD_ALT) {toggleFullScreen(); break;}
+
 						keyEvent.state = KBS_DOWN;
 						sshockKeyStates[c] = keyEvent.modifiers | KB_MOD_PRESSED;
 						addKBevent(&keyEvent);
@@ -349,15 +338,12 @@ void pump_events(void)
 
 				break;
 			}
-			case SDL_TEXTINPUT:
-				// ev.text.text is a char[32] UTF-8 string
-				// TODO: this is the proper way to get text input, and the only reliable way
-				//       to get the correct char for non-letter-key + shift (e.g. Shift+2 is " on German KB)
-				break;
 
 			case SDL_MOUSEBUTTONDOWN:
 			case SDL_MOUSEBUTTONUP:
 			{
+				if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS)) break;
+
 				bool down = (ev.button.state == SDL_PRESSED);
 				mouse_event mouseEvent = {0};
 				mouseEvent.type = 0;
@@ -365,41 +351,35 @@ void pump_events(void)
 				switch (ev.button.button)
 				{
 					case SDL_BUTTON_LEFT:
-						// TODO: the old mac code used to emulate right mouse clicks if space, enter, or return
-						//       was pressed at the same time - do the same? (=> could check sshockKeyStates[])
-
 						mouseEvent.type = down ? MOUSE_LDOWN : MOUSE_LUP;
-						break;
+					break;
 
 					case SDL_BUTTON_RIGHT:
 						mouseEvent.type = down ? MOUSE_RDOWN : MOUSE_RUP;
-						break;
-
-					//case SDL_BUTTON_MIDDLE: // TODO: is this MOUSE_CDOWN/UP ?
-					//		break;
-
+					break;
 				}
 
-				if(mouseEvent.type != 0)
+				if (mouseEvent.type != 0)
 				{
 					mouseEvent.x = ev.button.x;
 					mouseEvent.y = ev.button.y;
 					mouseEvent.timestamp = mouse_get_time();
 					mouseEvent.modifiers = 0;
-
 					addMouseEvent(&mouseEvent);
 				}
 
 				break;
 			}
+
 			case SDL_MOUSEMOTION:
 			{
+				if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS)) break;
+
 				mouse_event mouseEvent = {0};
 				mouseEvent.type = MOUSE_MOTION;
-				mouseEvent.x = ev.motion.x; // TODO: relative mode?
+				mouseEvent.x = ev.motion.x;
 				mouseEvent.y = ev.motion.y;
 				mouseEvent.timestamp = mouse_get_time();
-
 				addMouseEvent(&mouseEvent);
 
 				MouseLookX = ev.motion.x; //only update these when mouse actually moves
@@ -407,8 +387,12 @@ void pump_events(void)
 
 				break;
 			}
+
 			case SDL_MOUSEWHEEL:
-				if (ev.wheel.y != 0) {
+				if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS)) break;
+
+				if (ev.wheel.y != 0)
+				{
 					mouse_event mouseEvent = {0};
 					mouseEvent.type = ev.wheel.y < 0 ? MOUSE_WHEELDN : MOUSE_WHEELUP;
 					mouseEvent.x = latestMouseEvent.x;
@@ -416,14 +400,29 @@ void pump_events(void)
 					mouseEvent.timestamp = mouse_get_time();
 					addMouseEvent(&mouseEvent);
 				}
-				break;
+			break;
+
 			case SDL_WINDOWEVENT:
-				if (ev.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-					if(can_use_opengl()) {
-						opengl_resize(ev.window.data1, ev.window.data2);
-					}
+				if (ev.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+				{
+					if (can_use_opengl()) opengl_resize(ev.window.data1, ev.window.data2);
 				}
-			// TODO: maybe handle other events as well..
+
+				if (ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+				{
+					SDL_SetWindowBordered(window, !MouseCaptured);
+					SDL_SetWindowGrab(window, MouseCaptured);
+					SDL_ShowCursor(SDL_DISABLE);
+				}
+
+				if (ev.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+				{
+					SDL_SetWindowBordered(window, SDL_TRUE);
+					SDL_SetWindowGrab(window, SDL_FALSE);
+					SDL_ShowCursor(SDL_ENABLE);
+				}
+
+			break;
 		}
 	}
 }

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -713,7 +713,12 @@ errtype mouse_put_xy(short x, short y)
 		y = y * scale_x + ofs_y;
 	}
 
-	SDL_WarpMouseInWindow(window, x, y);
+	int window_x, window_y;
+	SDL_GetWindowPosition(window, &window_x, &window_y);
+	SDL_WarpMouseGlobal(window_x + x, window_y + y);
+
+	//creates a SDL_MOUSEMOTION event; feedback causes mouselook to go crazy
+	//SDL_WarpMouseInWindow(window, x, y);
 
 	return OK;
 }

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -344,6 +344,6 @@ void CaptureMouse(bool capture)
 {
 	MouseCaptured = (capture && gShockPrefs.goCaptureMouse);
 
-	SDL_SetWindowBordered(window, !MouseCaptured);
+	SDL_SetWindowResizable(window, !MouseCaptured);
 	SDL_SetWindowGrab(window, MouseCaptured);
 }

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -344,6 +344,6 @@ void CaptureMouse(bool capture)
 {
 	MouseCaptured = (capture && gShockPrefs.goCaptureMouse);
 
+	SDL_SetWindowBordered(window, !MouseCaptured);
 	SDL_SetWindowGrab(window, MouseCaptured);
-	SDL_SetWindowResizable(window, !MouseCaptured);
 }


### PR DESCRIPTION
Mouse events are handled only if cursor is in play area and window has input focus. If not, show desktop mouse cursor. Captured mouse cursor stays out of black border regions. **Commits finished.**