### PR TITLE
Fix floor texture map corruption

### DIFF
--- a/src/Libraries/2D/Source/Flat8/fl8lf.c
+++ b/src/Libraries/2D/Source/Flat8/fl8lf.c
@@ -40,131 +40,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 int gri_lit_floor_umap_loop(grs_tmap_loop_info *tli);
 
-/*extern "C"
-{
-extern int HandleFloorLoop_PPC(grs_tmap_loop_info *tli,
-                                                                                                                         fix u, fix v, fix du, fix dv, fix dx, fix i, fix di,
-                                                                                                                         uchar t_wlog, ulong	t_mask, uchar *t_bits, uchar *g_ltab);
-}*/
-
-int HandleFloorLoop_C(grs_tmap_loop_info *tli, fix u, fix v, fix du, fix dv, fix dx, fix i, fix di, uchar t_wlog,
-                      ulong t_mask, uchar *t_bits, uchar *g_ltab) {
-    uchar *p_dest;
-    int x;
-    fix inv;
-
-    do {
-        if ((x = fix_ceil(tli->right.x) - fix_ceil(tli->left.x)) > 0) {
-            x = fix_ceil(tli->left.x) - tli->left.x;
-
-            inv = fix_div(fix_make(1, 0) << 8, dx);
-            di = fix_mul_asm_safe_light(di, inv);
-            inv >>= 8;
-            du = fix_mul_asm_safe(du, inv);
-            dv = fix_mul_asm_safe(dv, inv);
-
-            u += fix_mul(du, x);
-            v += fix_mul(dv, x);
-            i += fix_mul(di, x);
-
-            // copy out tli-> stuff into locals
-            p_dest = grd_bm.bits + (grd_bm.row * tli->y) + fix_cint(tli->left.x);
-            x = fix_cint(tli->right.x) - fix_cint(tli->left.x);
-
-            while ((long)p_dest & 3 != 0) {
-                *(p_dest++) = g_ltab[t_bits[((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask] + fix_light(i)];
-                u += du;
-                v += dv;
-                i += di;
-                x--;
-            }
-
-            while (x >= 0) {
-                inv = g_ltab[t_bits[((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask] + fix_light(i)];
-                u += du;
-                v += dv;
-                i += di;
-                *p_dest = inv;
-                p_dest++;
-                x--;
-            }
-
-            for (; x > 0; x--) {
-                *(p_dest++) = g_ltab[t_bits[((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask] + fix_light(i)];
-                u += du;
-                v += dv;
-                i += di;
-            }
-        } else if (x < 0)
-            return TRUE; // punt this tmap
-
-        tli->w += tli->dw;
-
-        inv = fix_div(fix_make(1, 0), tli->w);
-        u = fix_mul_asm_safe((tli->left.u += tli->left.du), inv);
-        tli->right.u += tli->right.du;
-        du = fix_mul_asm_safe(tli->right.u, inv) - u;
-        v = fix_mul_asm_safe((tli->left.v += tli->left.dv), inv);
-        tli->right.v += tli->right.dv;
-        dv = fix_mul_asm_safe(tli->right.v, inv) - v;
-        i = fix_mul_asm_safe((tli->left.i += tli->left.di), inv);
-        tli->right.i += tli->right.di;
-        di = fix_mul_asm_safe(tli->right.i, inv) - i;
-
-        tli->left.x += tli->left.dx;
-        tli->right.x += tli->right.dx;
-        dx = tli->right.x - tli->left.x;
-        tli->y++;
-    } while (--(tli->n) > 0);
-
-    return FALSE; // tmap OK
-}
-
 int gri_lit_floor_umap_loop(grs_tmap_loop_info *tli) {
-    fix u, v, i, du, dv, di, dx, d;
-
-    // locals used to store copies of tli-> stuff, so its in registers on the PPC
-    int x, k;
-    uchar t_wlog;
-    ulong t_mask;
-    uchar *t_bits;
-    uchar *p_dest;
-    uchar *g_ltab;
-    fix inv;
-    long *t_vtab;
 
 #if InvDiv
-    inv = fix_div(fix_make(1, 0), tli->w);
-    u = fix_mul_asm_safe(tli->left.u, inv);
-    du = fix_mul_asm_safe(tli->right.u, inv) - u;
-    v = fix_mul_asm_safe(tli->left.v, inv);
-    dv = fix_mul_asm_safe(tli->right.v, inv) - v;
-    i = fix_mul_asm_safe(tli->left.i, inv);
-    di = fix_mul_asm_safe(tli->right.i, inv) - i;
+    fix inv = fix_div(fix_make(1, 0), tli->w);
+    fix u = fix_mul_asm_safe(tli->left.u, inv);
+    fix du = fix_mul_asm_safe(tli->right.u, inv) - u;
+    fix v = fix_mul_asm_safe(tli->left.v, inv);
+    fix dv = fix_mul_asm_safe(tli->right.v, inv) - v;
+    fix i = fix_mul_asm_safe(tli->left.i, inv);
+    fix di = fix_mul_asm_safe(tli->right.i, inv) - i;
 #else
-    u = fix_div(tli->left.u, tli->w);
-    du = fix_div(tli->right.u, tli->w) - u;
-    v = fix_div(tli->left.v, tli->w);
-    dv = fix_div(tli->right.v, tli->w) - v;
-    i = fix_div(tli->left.i, tli->w);
-    di = fix_div(tli->right.i, tli->w) - i;
+    fix u = fix_div(tli->left.u, tli->w);
+    fix du = fix_div(tli->right.u, tli->w) - u;
+    fix v = fix_div(tli->left.v, tli->w);
+    fix dv = fix_div(tli->right.v, tli->w) - v;
+    fix i = fix_div(tli->left.i, tli->w);
+    fix di = fix_div(tli->right.i, tli->w) - i;
 #endif
 
-    dx = tli->right.x - tli->left.x;
-
-    t_mask = tli->mask;
-    t_wlog = tli->bm.wlog;
-    g_ltab = grd_screen->ltab;
-
-    t_vtab = tli->vtab;
-    t_bits = tli->bm.bits;
-
-    if (tli->bm.hlog == (GRL_OPAQUE | GRL_LOG2))
-        return HandleFloorLoop_C(tli, u, v, du, dv, dx, i, di, t_wlog, t_mask, t_bits, g_ltab);
+    ulong t_mask = tli->mask;
+    uchar t_wlog = tli->bm.wlog;
+    uchar *g_ltab = grd_screen->ltab;
+    long *t_vtab = tli->vtab;
+    uchar *t_bits = tli->bm.bits;
 
     do {
-        if ((d = fix_ceil(tli->right.x) - fix_ceil(tli->left.x)) > 0) {
-            d = fix_ceil(tli->left.x) - tli->left.x;
+        fix dx = tli->right.x - tli->left.x;
+        if (dx > 0)
+        {
 
 #if InvDiv
             inv = fix_div(fix_make(1, 0) << 8, dx);
@@ -177,56 +81,61 @@ int gri_lit_floor_umap_loop(grs_tmap_loop_info *tli) {
             dv = fix_div(dv, dx);
             di = fix_div(di, dx);
 #endif
+
+            fix d = fix_ceil(tli->left.x) - tli->left.x;
             u += fix_mul(du, d);
             v += fix_mul(dv, d);
             i += fix_mul(di, d);
 
-            // copy out tli-> stuff into locals
-            p_dest = grd_bm.bits + (grd_bm.row * tli->y) + fix_cint(tli->left.x);
-            x = fix_cint(tli->right.x) - fix_cint(tli->left.x);
+            uchar *p_dest = grd_bm.bits + (grd_bm.row * tli->y) + fix_cint(tli->left.x);
+
+            int x = fix_cint(tli->right.x) - fix_cint(tli->left.x);
 
             switch (tli->bm.hlog) {
-            case GRL_OPAQUE:
-                for (; x > 0; x--) {
-                    k = t_vtab[fix_fint(v)] + fix_fint(u);
-                    *(p_dest++) =
-                        g_ltab[t_bits[k] + fix_light(i)]; // gr_fill_upixel(g_ltab[t_bits[k]+fix_light(i)],x,t_y);
-                }
+                case GRL_OPAQUE:
+                    for (; x > 0; x--) {
+                        int k = t_vtab[fix_fint(v)] + fix_fint(u);
+                        *(p_dest++) = g_ltab[t_bits[k] + fix_light(i)];
+                        // gr_fill_upixel(g_ltab[t_bits[k]+fix_light(i)],x,t_y);
+                    }
                 break;
-            case GRL_TRANS:
-                for (; x > 0; x--) {
-                    k = t_vtab[fix_fint(v)] + fix_fint(u);
-                    if (k = t_bits[k])
-                        *p_dest = g_ltab[k + fix_light(i)]; // gr_fill_upixel(g_ltab[k+fix_light(i)],x,t_y);
-                    p_dest++;
-                    u += du;
-                    v += dv;
-                    i += di;
-                }
+
+                case GRL_TRANS:
+                    for (; x > 0; x--) {
+                        int k = t_vtab[fix_fint(v)] + fix_fint(u);
+                        if (k = t_bits[k]) *p_dest = g_ltab[k + fix_light(i)];
+                        // gr_fill_upixel(g_ltab[k+fix_light(i)],x,t_y);
+                        p_dest++;
+                        u += du;
+                        v += dv;
+                        i += di;
+                    }
                 break;
-                // special case handles this
-                /*      case GRL_OPAQUE|GRL_LOG2:
-                          for (; x>0; x--) {
-                            k=((fix_fint(v)<<t_wlog)+fix_fint(u))&t_mask;
-                              *(p_dest++) = g_ltab[t_bits[k]+fix_light(i)];		//
-                   gr_fill_upixel(g_ltab[t_bits[k]+fix_light(i)],x,t_y); u+=du; v+=dv;
-                   i+=di;
-                         }
-                         break;*/
-            case GRL_TRANS | GRL_LOG2:
-                for (; x > 0; x--) {
-                    k = ((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask;
-                    if (k = t_bits[k])
-                        *p_dest = g_ltab[k + fix_light(i)]; // gr_fill_upixel(g_ltab[k+fix_light(i)],x,t_y);
-                    p_dest++;
-                    u += du;
-                    v += dv;
-                    i += di;
-                }
+
+                case GRL_OPAQUE|GRL_LOG2:
+                    for (; x > 0; x--) {
+                        int k = ((fix_fint(v)<<t_wlog)+fix_fint(u))&t_mask;
+                        *(p_dest++) = g_ltab[t_bits[k]+fix_light(i)];
+                        // gr_fill_upixel(g_ltab[t_bits[k]+fix_light(i)],x,t_y);
+                        u += du;
+                        v += dv;
+                        i += di;
+                    }
+                break;
+
+                case GRL_TRANS | GRL_LOG2:
+                    for (; x > 0; x--) {
+                        int k = ((fix_fint(v) << t_wlog) + fix_fint(u)) & t_mask;
+                        if (k = t_bits[k]) *p_dest = g_ltab[k + fix_light(i)];
+                        // gr_fill_upixel(g_ltab[k+fix_light(i)],x,t_y);
+                        p_dest++;
+                        u += du;
+                        v += dv;
+                        i += di;
+                    }
                 break;
             }
-        } else if (d < 0)
-            return TRUE; /* punt this tmap */
+        }
 
         tli->w += tli->dw;
 
@@ -255,10 +164,12 @@ int gri_lit_floor_umap_loop(grs_tmap_loop_info *tli) {
 
         tli->left.x += tli->left.dx;
         tli->right.x += tli->right.dx;
-        dx = tli->right.x - tli->left.x;
+
         tli->y++;
+
     } while (--(tli->n) > 0);
-    return FALSE; /* tmap OK */
+
+    return FALSE; // tmap OK
 }
 
 void gri_trans_lit_floor_umap_init(grs_tmap_loop_info *tli) {


### PR DESCRIPTION
Floor/ceiling horizontal span drawing was occasionally spilling over by one pixel. For example, a vertical line of pixels from a floor on the player's right would appear on the left edge of the screen.
The rightmost pixel of a span sometimes went outside bounds of texture, causing corruption.
Also more strict checking for divide by zero, and cleanup of function.