### PR TITLE
Bitmap uncompress malloc'ed space too small

### DIFF
--- a/src/Libraries/AFILE/Source/afile.c
+++ b/src/Libraries/AFILE/Source/afile.c
@@ -78,7 +78,7 @@ static Amethods *methods[] = {
 
 //	Allocate enough room in case RSD goes overboard
 
-#define BM_PLENTY_SIZE(szuncomp) (((szuncomp)*2) + 512)
+#define BM_PLENTY_SIZE(szuncomp)  (szuncomp*3)
 
 //	-------------------------------------------------------
 //		GENERAL ACCESS ROUTINES - READING


### PR DESCRIPTION
Cause of bottom of cutscene bmp pixel corruption