### PR TITLE
Fix cyberspace mouselook

### DIFF
--- a/src/GameSrc/mouselook.c
+++ b/src/GameSrc/mouselook.c
@@ -37,11 +37,15 @@ void mouse_look_physics() {
 
     int mvelx, mvely;
 	get_mouselook_vel(&mvelx, &mvely);
-    mvelx *= -mlook_hsens;
-    mvely *= -mlook_vsens;
 
-    if (global_fullmap->cyber == FALSE) {
+    if (global_fullmap->cyber) {
+        //see physics_run() in physics.c
+        mlook_vel_x = -mvelx;
+        mlook_vel_y = -mvely;
+    } else {
         // player head controls
+        mvelx *= -mlook_hsens;
+        mvely *= -mlook_vsens;
 
         if (mvely != 0) {
             // Moving the eye up angle is easy


### PR DESCRIPTION
which I broke with relative mouse mode.

I didn't realize glob vars mlook_vel_x & y were read in physics.c and declared in mouselook.h.