### PR TITLE
Fix automap scrolling

### DIFF
--- a/src/GameSrc/fullamap.c
+++ b/src/GameSrc/fullamap.c
@@ -76,7 +76,7 @@ errtype amap_init(void) {
     LGRect mac_rect = {{0, 0}, {640, 480}};
 
     generic_reg_init(TRUE, &amap_root_region, &mac_rect, &amap_slab, amap_key_handler, amap_mouse_handler);
-    uiInstallRegionHandler(&amap_root_region, UI_EVENT_KBD_POLL | UI_EVENT_MOUSE_MOVE, amap_scroll_handler, NULL, &id);
+    uiInstallRegionHandler(&amap_root_region, UI_EVENT_KBD_POLL | UI_EVENT_MOUSE, amap_scroll_handler, NULL, &id);
     return (OK);
 }
 


### PR DESCRIPTION
Symptoms: NSWE buttons and scrolling keys weren't working.

Code that checks which NSWE button pressed was faulty. Input polling was limited to mouse movements and not clicking. This caused scrolling function to not be called when clicking.

Keys weren't working because function that scrolls map was returning before actually checking keys.
Working keys made map jump because time elapsed calculation was not limited.

Map can be scrolled with cursor or numeric keypad keys.