### PR TITLE
Implement user-definable keys

### DIFF
--- a/src/GameSrc/Headers/movekeys.h
+++ b/src/GameSrc/Headers/movekeys.h
@@ -1,0 +1,55 @@
+/*
+
+Copyright (C) 2015-2018 Night Dive Studios, LLC.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+#define MAX_MOVE_KEYBINDS  256
+
+typedef struct MOVE_KEYBIND_STRUCT {int code, move;} MOVE_KEYBIND;
+
+enum
+{
+  M_RUNFORWARD,
+  M_FORWARD,
+  M_FASTTURNLEFT,
+  M_TURNLEFT,
+  M_FASTTURNRIGHT,
+  M_TURNRIGHT,
+  M_BACK,
+  M_SLIDELEFT,
+  M_SLIDERIGHT,
+  M_JUMP,
+  M_LEANUP,
+  M_LEANLEFT,
+  M_LEANRIGHT,
+  M_LOOKUP,
+  M_LOOKDOWN,
+  M_RUNLEFT,
+  M_RUNRIGHT,
+  M_THRUST, //cyber start
+  M_CLIMB,
+  M_BANKLEFT,
+  M_BANKRIGHT,
+  M_DIVE,
+  M_ROLLRIGHT,
+  M_ROLLLEFT,
+  M_CLIMBLEFT,
+  M_CLIMBRIGHT,
+  M_DIVERIGHT,
+  M_DIVELEFT,
+
+  NUM_MOVES
+};

--- a/src/GameSrc/input.c
+++ b/src/GameSrc/input.c
@@ -126,10 +126,6 @@ extern bool DoubleSize;
 #define CFG_OOMPHOMETER "throw_oomph"
 #define CFG_INP6D_GO "inp6d"
 
-#define DOWN(x) ((x) | KB_FLAG_DOWN)
-#define CONTROL(x) (DOWN(x) | KB_FLAG_CTRL)
-#define ALT(x) (DOWN(x) | KB_FLAG_ALT)
-
 ubyte use_distance_mod = 0;
 ubyte pickup_distance_mod = 0;
 ubyte fatigue_threshold = 5;
@@ -244,7 +240,6 @@ uchar change_gamma(short keycode, ulong context, void *data);
 // -------------
 void handle_keyboard_fatigue(void);
 void poll_mouse(void);
-uchar posture_hotkey_func(short keycode, ulong context, void *data);
 uchar eye_hotkey_func(short keycode, ulong context, int data);
 
 void reload_motion_cursors(uchar cyber);
@@ -259,11 +254,12 @@ void view3d_rightbutton_handler(uiMouseEvent *ev, LGRegion *r, view3d_data *data
 uchar view3d_key_handler(uiCookedKeyEvent *ev, LGRegion *r, void *data);
 void use_object_in_3d(ObjID obj);
 
-uchar MacQuitFunc(short keycode, ulong context, void *data);
 uchar MacResFunc(short keycode, ulong context, void *data);
 uchar MacSkiplinesFunc(short keycode, ulong context, void *data);
-uchar MacDetailFunc(short keycode, ulong context, void *data);
-uchar MacHelpFunc(short keycode, ulong context, void *data);
+
+//EXTERN FUNCTIONS
+
+extern uchar cycle_weapons_func(short keycode, ulong context, void *data);
 
 // -------------
 // INPUT POLLING
@@ -989,16 +985,10 @@ static ushort eye_lvl_keys[] = {
 #define NUM_EYE_LVL_KEYS (sizeof(eye_lvl_keys) / sizeof(ushort))
 // -------------------------------------
 // INITIALIZATION
-extern uchar reload_weapon_hotkey(short keycode, ulong context, void *data);
 extern errtype simple_load_res_bitmap_cursor(LGCursor *c, grs_bitmap *bmp, Ref rid);
 extern uchar unpause_game_func(short keycode, ulong context, void *data);
-extern uchar saveload_hotkey_func(short keycode, ulong context, void *data);
-#ifdef AUDIOLOGS
-extern uchar audiolog_cancel_func(short keycode, ulong context, void *data);
-#endif
 extern uchar keyhelp_hotkey_func(short keycode, ulong context, void *data);
 extern uchar demo_quit_func(short keycode, ulong context, void *data);
-extern uchar hud_color_bank_cycle(short keycode, ulong context, void *data);
 extern void init_side_icon_hotkeys(void);
 extern void init_invent_hotkeys(void);
 extern uchar toggle_view_func(short keycode, ulong context, void *data);
@@ -1014,8 +1004,6 @@ extern uchar change_clipper(short keycode, ulong context, void *data);
 extern uchar version_spew_func(short keycode, ulong context, void *data);
 extern uchar location_spew_func(short keycode, ulong context, void *data);
 #endif
-
-extern uchar toggle_mouse_look(short keycode, ulong context, void *data);
 
 #define ckpoint_input(val) Spew(DSRC_TESTING_Test0, ("ii %s @%d\n", val, *tmd_ticks));
 
@@ -1217,6 +1205,19 @@ uchar toggle_opengl_func(short keycode, ulong context, void *data) {
     return TRUE;
 }
 
+//most of original init_input() is now either commented out or done elsewhere, so do what's left here
+//and comment out original function below
+void init_input(void) {
+    uiDoubleClickDelay = 8;
+    uiDoubleClickTime = 45;
+    uiDoubleClicksOn[MOUSE_LBUTTON] = TRUE; // turn on left double clicks
+    uiAltDoubleClick = TRUE;
+
+    alloc_cursor_bitmaps();
+    reload_motion_cursors(FALSE);
+}
+
+/*
 void init_input(void) {
     extern void init_motion_polling();
     int i = 0;
@@ -1228,14 +1229,14 @@ void init_input(void) {
     // KLC	kb_clear_state(i,KBA_REPEAT);
     hotkey_init(NUM_HOTKEYS);
 
-    /* KLC
-       kbdt=dt_keyboard();
-       if (kbdt!=kb_get_country())
-       {
-               kb_set_country(kbdt);
-          Warning(("Setting kb country to %d\n",kbdt));
-       }
-    */
+    // KLC
+    // kbdt=dt_keyboard();
+    // if (kbdt!=kb_get_country())
+    // {
+    //         kb_set_country(kbdt);
+    //    Warning(("Setting kb country to %d\n",kbdt));
+    // }
+    //
     init_motion_polling();
 
     // init mouse
@@ -1272,11 +1273,11 @@ void init_input(void) {
     hotkey_add(CONTROL('l'), DEMO_CONTEXT, saveload_hotkey_func, (void *)TRUE);
     hotkey_add(CONTROL('L'), DEMO_CONTEXT, saveload_hotkey_func, (void *)TRUE);
 
-    /*KLC - not in Mac version
-       hotkey_add('?', DEMO_CONTEXT, keyhelp_hotkey_func, NULL);
-
-       hotkey_add('/',DEMO_CONTEXT,toggle_bool_func,&joystick_mouse_emul);
-    */
+    //KLC - not in Mac version
+    // hotkey_add('?', DEMO_CONTEXT, keyhelp_hotkey_func, NULL);
+    //
+    // hotkey_add('/',DEMO_CONTEXT,toggle_bool_func,&joystick_mouse_emul);
+    //
     hotkey_add(ALT(KEY_BS), DEMO_CONTEXT, reload_weapon_hotkey, (void *)0);
     hotkey_add(CONTROL(KEY_BS), DEMO_CONTEXT, reload_weapon_hotkey, (void *)1);
     hotkey_add(ALT('\''), DEMO_CONTEXT, arm_grenade_hotkey, (void *)0);
@@ -1314,13 +1315,13 @@ void init_input(void) {
     hotkey_add(CONTROL('/'), DEMO_CONTEXT, MacHelpFunc, NULL);
     hotkey_add(CONTROL('?'), DEMO_CONTEXT, MacHelpFunc, NULL);
 
-    /*
-       hotkey_add(ALT('x'),DEMO_CONTEXT,demo_quit_func,NULL);
-       hotkey_add(ALT('x'),SETUP_CONTEXT,really_quit_key_func,NULL);
-       hotkey_add(ALT('v'),DEMO_CONTEXT,toggle_view_func,NULL);
-       hotkey_add(ALT('V'),DEMO_CONTEXT,toggle_view_func,NULL);
-       hotkey_add(ALT(KEY_F7),DEMO_CONTEXT,version_spew_func,NULL);
-    */
+    //
+    // hotkey_add(ALT('x'),DEMO_CONTEXT,demo_quit_func,NULL);
+    // hotkey_add(ALT('x'),SETUP_CONTEXT,really_quit_key_func,NULL);
+    // hotkey_add(ALT('v'),DEMO_CONTEXT,toggle_view_func,NULL);
+    // hotkey_add(ALT('V'),DEMO_CONTEXT,toggle_view_func,NULL);
+    // hotkey_add(ALT(KEY_F7),DEMO_CONTEXT,version_spew_func,NULL);
+    //
     //   hotkey_add(CONTROL('8'),DEMO_CONTEXT,location_spew_func,NULL);  //testing
     //   hotkey_add(CONTROL('0'),DEMO_CONTEXT,temp_FrameCounter_func, NULL); //testing
 
@@ -1328,153 +1329,154 @@ void init_input(void) {
     hotkey_add(CONTROL('D'), DEMO_CONTEXT, change_mode_func, (void *)FULLSCREEN_LOOP);
     hotkey_add(CONTROL('a'), DEMO_CONTEXT, change_mode_func, (void *)AUTOMAP_LOOP);
     hotkey_add(CONTROL('A'), DEMO_CONTEXT, change_mode_func, (void *)AUTOMAP_LOOP);
-    /*
-    #else
-       hotkey_add(DOWN(KEY_SPACE),DEMO_CONTEXT,unpause_game_func,(void *)TRUE);
-       hotkey_add(CONTROL('a'), DEMO_CONTEXT, change_mode_func,  (void *) AUTOMAP_LOOP);
-       hotkey_add(CONTROL('A'), DEMO_CONTEXT, change_mode_func,  (void *) AUTOMAP_LOOP);
-
-       hotkey_add_help(DOWN(KEY_BS), DEMO_CONTEXT,clear_fullscreen_func, NULL,
-          "Clears all overlays from the fullscreen view.");
-       hotkey_add_help(DOWN(KEY_PAUSE),DEMO_CONTEXT,pause_game_func,(void *)TRUE, "pause the game, gee.");
-       hotkey_add_help(DOWN('p'),DEMO_CONTEXT,pause_game_func,(void *)TRUE, "pause the game, gee.");
-       hotkey_add_help(DOWN(KEY_ESC),DEMO_CONTEXT,wrapper_options_func,(void *)TRUE,
-          "Opens up the options menu on the main game screen.");
-       hotkey_add_help(CONTROL('h'), DEMO_CONTEXT, hud_color_bank_cycle, NULL, "cycle hud colors");
-       hotkey_add_help(CONTROL('H'), DEMO_CONTEXT, hud_color_bank_cycle, NULL, "cycle hud colors");
-       hotkey_add_help(CONTROL(ALT('~')),EVERY_CONTEXT,toggle_profile,(void *)TRUE, "toggle profile");
-
-       for (i = 0; i < NUM_POSTURES; i++)
-       {
-          hotkey_add_help(DOWN(posture_keys[i]),DEMO_CONTEXT,posture_hotkey_func,(void*)i,"change posture");
-          hotkey_add_help(DOWN(toupper(posture_keys[i])),DEMO_CONTEXT,posture_hotkey_func,(void*)i,"change posture");
-       }
-       hotkey_add_help(ALT('x'),EDIT_CONTEXT|SETUP_CONTEXT,quit_key_func,NULL,"quit, but ask for confirm.");
-       hotkey_add_help(ALT('x'),DEMO_CONTEXT,demo_quit_func,NULL,"quit, but ask for confirm on options panel.");
-       hotkey_add_help(ALT('X'),EVERY_CONTEXT,really_quit_key_func,NULL, "quit, no questions asked.");
-       hotkey_add_help(ALT('v'),EVERY_CONTEXT,toggle_view_func,NULL, "toggles between game mode and fullscreen mode.");
-       hotkey_add_help(ALT('V'),EVERY_CONTEXT,toggle_view_func,NULL, "toggles between game mode and fullscreen mode.");
-       hotkey_add(ALT('d'),EVERY_CONTEXT,mono_config_func,NULL);
-
-       // these are some random hotkeys - debugging
-       hotkey_add(CONTROL('q'),EVERY_CONTEXT,maim_player,"maim player");
-       hotkey_add(CONTROL('z'),EVERY_CONTEXT,change_clipper,"maim player");
-       hotkey_add(ALT(KEY_F2),EVERY_CONTEXT,salt_the_player, "Salt the Player");
-       hotkey_add(ALT(KEY_F3),EVERY_CONTEXT,give_player_hotkey, "Give Player Loot");
-
-       // Meta-slewing
-       hotkey_add(DOWN('r'), EDIT_CONTEXT, stupid_slew_func, (void *)13);
-       hotkey_add(DOWN('>'), DEMO_CONTEXT|EDIT_CONTEXT, stupid_slew_func, (void *)14);
-       hotkey_add(DOWN('<'), DEMO_CONTEXT|EDIT_CONTEXT, stupid_slew_func, (void *)15);
-
-       // 3d zoomin
-       hotkey_add(CONTROL('['), DEMO_CONTEXT|EDIT_CONTEXT, zoom_3d_func, (void *)TRUE);
-       hotkey_add(CONTROL(']'), DEMO_CONTEXT|EDIT_CONTEXT, zoom_3d_func, (void *)FALSE);
-
-       ckpoint_input("hotkeys in");
-
+    //
+    //#else
+    //   hotkey_add(DOWN(KEY_SPACE),DEMO_CONTEXT,unpause_game_func,(void *)TRUE);
+    //   hotkey_add(CONTROL('a'), DEMO_CONTEXT, change_mode_func,  (void *) AUTOMAP_LOOP);
+    //   hotkey_add(CONTROL('A'), DEMO_CONTEXT, change_mode_func,  (void *) AUTOMAP_LOOP);
+    //
+    //   hotkey_add_help(DOWN(KEY_BS), DEMO_CONTEXT,clear_fullscreen_func, NULL,
+    //      "Clears all overlays from the fullscreen view.");
+    //   hotkey_add_help(DOWN(KEY_PAUSE),DEMO_CONTEXT,pause_game_func,(void *)TRUE, "pause the game, gee.");
+    //   hotkey_add_help(DOWN('p'),DEMO_CONTEXT,pause_game_func,(void *)TRUE, "pause the game, gee.");
+    //   hotkey_add_help(DOWN(KEY_ESC),DEMO_CONTEXT,wrapper_options_func,(void *)TRUE,
+    //      "Opens up the options menu on the main game screen.");
+    //   hotkey_add_help(CONTROL('h'), DEMO_CONTEXT, hud_color_bank_cycle, NULL, "cycle hud colors");
+    //   hotkey_add_help(CONTROL('H'), DEMO_CONTEXT, hud_color_bank_cycle, NULL, "cycle hud colors");
+    //   hotkey_add_help(CONTROL(ALT('~')),EVERY_CONTEXT,toggle_profile,(void *)TRUE, "toggle profile");
+    //
+    //   for (i = 0; i < NUM_POSTURES; i++)
+    //   {
+    //      hotkey_add_help(DOWN(posture_keys[i]),DEMO_CONTEXT,posture_hotkey_func,(void*)i,"change posture");
+    //      hotkey_add_help(DOWN(toupper(posture_keys[i])),DEMO_CONTEXT,posture_hotkey_func,(void*)i,"change posture");
+    //   }
+    //   hotkey_add_help(ALT('x'),EDIT_CONTEXT|SETUP_CONTEXT,quit_key_func,NULL,"quit, but ask for confirm.");
+    //   hotkey_add_help(ALT('x'),DEMO_CONTEXT,demo_quit_func,NULL,"quit, but ask for confirm on options panel.");
+    //   hotkey_add_help(ALT('X'),EVERY_CONTEXT,really_quit_key_func,NULL, "quit, no questions asked.");
+    //   hotkey_add_help(ALT('v'),EVERY_CONTEXT,toggle_view_func,NULL, "toggles between game mode and fullscreen mode.");
+    //   hotkey_add_help(ALT('V'),EVERY_CONTEXT,toggle_view_func,NULL, "toggles between game mode and fullscreen mode.");
+    //   hotkey_add(ALT('d'),EVERY_CONTEXT,mono_config_func,NULL);
+    //
+    //   // these are some random hotkeys - debugging
+    //   hotkey_add(CONTROL('q'),EVERY_CONTEXT,maim_player,"maim player");
+    //   hotkey_add(CONTROL('z'),EVERY_CONTEXT,change_clipper,"maim player");
+    //   hotkey_add(ALT(KEY_F2),EVERY_CONTEXT,salt_the_player, "Salt the Player");
+    //   hotkey_add(ALT(KEY_F3),EVERY_CONTEXT,give_player_hotkey, "Give Player Loot");
+    //
+    //   // Meta-slewing
+    //   hotkey_add(DOWN('r'), EDIT_CONTEXT, stupid_slew_func, (void *)13);
+    //   hotkey_add(DOWN('>'), DEMO_CONTEXT|EDIT_CONTEXT, stupid_slew_func, (void *)14);
+    //   hotkey_add(DOWN('<'), DEMO_CONTEXT|EDIT_CONTEXT, stupid_slew_func, (void *)15);
+    //
+    //   // 3d zoomin
+    //   hotkey_add(CONTROL('['), DEMO_CONTEXT|EDIT_CONTEXT, zoom_3d_func, (void *)TRUE);
+    //   hotkey_add(CONTROL(']'), DEMO_CONTEXT|EDIT_CONTEXT, zoom_3d_func, (void *)FALSE);
+    //
+    //   ckpoint_input("hotkeys in");
+    //
     //   hotkey_add(DOWN('['),EDIT_CONTEXT,zoom_func,(void *)ZOOM_IN);
     //   hotkey_add(DOWN(']'),EDIT_CONTEXT,zoom_func,(void *)ZOOM_OUT);
     //   hotkey_add(CONTROL('d'),EDIT_CONTEXT,to_demo_mode_func,NULL);
-
-    #endif
-       hotkey_add(KEY_F11,DEMO_CONTEXT|EDIT_CONTEXT,change_gamma,(void *) 1);
-       hotkey_add(KEY_F12,DEMO_CONTEXT|EDIT_CONTEXT,change_gamma,(void *)-1);
-    */
+    //
+    //#endif
+    //   hotkey_add(KEY_F11,DEMO_CONTEXT|EDIT_CONTEXT,change_gamma,(void *) 1);
+    //   hotkey_add(KEY_F12,DEMO_CONTEXT|EDIT_CONTEXT,change_gamma,(void *)-1);
+    //
     hotkey_add(CONTROL('h'), DEMO_CONTEXT, toggle_olh_func, NULL);
     hotkey_add(CONTROL('H'), DEMO_CONTEXT, toggle_olh_func, NULL);
     hotkey_add(ALT('o'), DEMO_CONTEXT, olh_overlay_func, &olh_overlay_on);
     hotkey_add(ALT('O'), DEMO_CONTEXT, olh_overlay_func, &olh_overlay_on);
     hotkey_add(CONTROL('g'), EVERY_CONTEXT, toggle_opengl_func, NULL);
-    /*
-       // take these ifdefs out if memory bashing on shippable
-    //   hotkey_add(ALT(CONTROL(KEY_F4)),EVERY_CONTEXT,texture_annihilate_func,NULL);
-    #ifdef RCACHE_TEST
-       hotkey_add(ALT(KEY_F4),EVERY_CONTEXT,res_cache_usage_func,(void *)TRUE);
-       hotkey_add(CONTROL(KEY_F4),EVERY_CONTEXT,res_cache_usage_func,(void *)FALSE);
-    #endif
-       init_side_icon_hotkeys();
-    */
+    //
+    //   // take these ifdefs out if memory bashing on shippable
+    ////   hotkey_add(ALT(CONTROL(KEY_F4)),EVERY_CONTEXT,texture_annihilate_func,NULL);
+    //#ifdef RCACHE_TEST
+    //   hotkey_add(ALT(KEY_F4),EVERY_CONTEXT,res_cache_usage_func,(void *)TRUE);
+    //   hotkey_add(CONTROL(KEY_F4),EVERY_CONTEXT,res_cache_usage_func,(void *)FALSE);
+    //#endif
+    //   init_side_icon_hotkeys();
+    //
     init_invent_hotkeys();
 
-    /*for (i = 0; i < NUM_EYE_LVL_KEYS; i++)
-    {
-       hotkey_add(DOWN(eye_lvl_keys[i]),DEMO_CONTEXT,(hotkey_callback)eye_hotkey_func,(void*)0);
-    }*/
+    //for (i = 0; i < NUM_EYE_LVL_KEYS; i++)
+    //{
+    //   hotkey_add(DOWN(eye_lvl_keys[i]),DEMO_CONTEXT,(hotkey_callback)eye_hotkey_func,(void*)0);
+    //}
 
-    /* KLC - stuff for VR headsets
-       if (config_get_raw(CFG_INP6D_GO,NULL,0))
-       {
-               ckpoint_input("inp6d start");
-
-          // hack for these config variables, not sure where else to put them
-          inp6d_hdouble = config_get_raw("inp6d_hdouble",NULL,0);
-          inp6d_pdouble = config_get_raw("inp6d_pdouble",NULL,0);
-          inp6d_bdouble = config_get_raw("inp6d_bdouble",NULL,0);
-
-    #if defined(VFX1_SUPPORT)||defined(CTM_SUPPORT)||defined(SPACEBALL_SUPPORT)
-               inp6d_exists=(i6_probe()==0 && i6_startup()==0);
-          if ((config_get_raw("inp6d_force",NULL,0)))
-            inp6d_exists=(i6_force(I6D_VFX1) == 0);
-    #else
-               inp6d_exists=(i6_probe_small()==0 && i6_startup()==0);
-    #endif
-    #if defined(VFX1_SUPPORT)||defined(CTM_SUPPORT)
-          if ((i6d_device==I6D_VFX1)||(i6d_device==I6D_CTM)||(i6d_device==I6D_ALLPRO))
-          {
-             extern uchar fullscrn_vitals, fullscrn_icons;
-             i6s_event *inp6d_geth;
-             do {
-                inp6d_geth=i6_poll();
-             } while (inp6d_geth==NULL);
-
-             {
-                hotkey_add(ALT('g'),DEMO_CONTEXT|EDIT_CONTEXT,recenter_headset,NULL);
-                inp6d_headset=TRUE;
-                     tracker_initial_pos[0]= inp6d_geth->ry;
-                     tracker_initial_pos[1]= inp6d_geth->rx;
-                     tracker_initial_pos[2]=-inp6d_geth->rz;
-                     fullscrn_vitals=fullscrn_icons=FALSE;
-                if (i6_video(I6VID_STARTUP,NULL))
-                   Warning(("Headset video startup failed\n"));
-                  if ((config_get_raw("inp6d_stereo",NULL,0))&&(i6d_device!=I6D_ALLPRO))
-                {
-                   int cnt=1, rval[1];
-                        if (i6_video(I6VID_STR_START,NULL))
-                           Warning(("Headset stereo startup failed\n"));
-                   else
-                    { inp6d_stereo=TRUE; inp6d_stereo_active=FALSE; }
-                   config_get_value("inp6d_stereo",CONFIG_INT_TYPE,rval,&cnt);
-                   if (cnt>0) inp6d_stereo_div=rval[0];
-                }
-                  if (config_get_raw("inp6d_doom",NULL,0))
-                   inp6d_doom=TRUE;
-             }
-          }     // end of is it a tracker....
-    #endif
-               ckpoint_input("inp6d end");
-       } else inp6d_exists=FALSE;
-       {
-          int cnt=1, rval[1];
-          config_get_value("joystick",CONFIG_INT_TYPE,rval,&cnt);
-          if (cnt>0)
-          {
-             extern ushort wrap_joy_type;
-             extern ushort high_joy_flags;
-             joy_type=rval[0];
-             wrap_joy_type  = joy_type & ~JOY_NO_NGP;
-             high_joy_flags = joy_type & JOY_NO_NGP;
-          }
-       }
-       if (joystick_count=joy_init(joy_type))
-       {
-    #ifdef PLAYTEST
-          mprintf("Got %d joystick pots\n",joystick_count);
-    #endif
-          hotkey_add(ALT('j'),DEMO_CONTEXT|EDIT_CONTEXT,recenter_joystick,NULL);
-       }
-     */
+    // KLC - stuff for VR headsets
+    //   if (config_get_raw(CFG_INP6D_GO,NULL,0))
+    //   {
+    //           ckpoint_input("inp6d start");
+    //
+    //      // hack for these config variables, not sure where else to put them
+    //      inp6d_hdouble = config_get_raw("inp6d_hdouble",NULL,0);
+    //      inp6d_pdouble = config_get_raw("inp6d_pdouble",NULL,0);
+    //      inp6d_bdouble = config_get_raw("inp6d_bdouble",NULL,0);
+    //
+    //#if defined(VFX1_SUPPORT)||defined(CTM_SUPPORT)||defined(SPACEBALL_SUPPORT)
+    //           inp6d_exists=(i6_probe()==0 && i6_startup()==0);
+    //      if ((config_get_raw("inp6d_force",NULL,0)))
+    //        inp6d_exists=(i6_force(I6D_VFX1) == 0);
+    //#else
+    //           inp6d_exists=(i6_probe_small()==0 && i6_startup()==0);
+    //#endif
+    //#if defined(VFX1_SUPPORT)||defined(CTM_SUPPORT)
+    //      if ((i6d_device==I6D_VFX1)||(i6d_device==I6D_CTM)||(i6d_device==I6D_ALLPRO))
+    //      {
+    //         extern uchar fullscrn_vitals, fullscrn_icons;
+    //         i6s_event *inp6d_geth;
+    //         do {
+    //            inp6d_geth=i6_poll();
+    //         } while (inp6d_geth==NULL);
+    //
+    //         {
+    //            hotkey_add(ALT('g'),DEMO_CONTEXT|EDIT_CONTEXT,recenter_headset,NULL);
+    //            inp6d_headset=TRUE;
+    //                 tracker_initial_pos[0]= inp6d_geth->ry;
+    //                 tracker_initial_pos[1]= inp6d_geth->rx;
+    //                 tracker_initial_pos[2]=-inp6d_geth->rz;
+    //                 fullscrn_vitals=fullscrn_icons=FALSE;
+    //            if (i6_video(I6VID_STARTUP,NULL))
+    //               Warning(("Headset video startup failed\n"));
+    //              if ((config_get_raw("inp6d_stereo",NULL,0))&&(i6d_device!=I6D_ALLPRO))
+    //            {
+    //               int cnt=1, rval[1];
+    //                    if (i6_video(I6VID_STR_START,NULL))
+    //                       Warning(("Headset stereo startup failed\n"));
+    //               else
+    //                { inp6d_stereo=TRUE; inp6d_stereo_active=FALSE; }
+    //               config_get_value("inp6d_stereo",CONFIG_INT_TYPE,rval,&cnt);
+    //               if (cnt>0) inp6d_stereo_div=rval[0];
+    //            }
+    //              if (config_get_raw("inp6d_doom",NULL,0))
+    //               inp6d_doom=TRUE;
+    //         }
+    //      }     // end of is it a tracker....
+    //#endif
+    //           ckpoint_input("inp6d end");
+    //   } else inp6d_exists=FALSE;
+    //   {
+    //      int cnt=1, rval[1];
+    //      config_get_value("joystick",CONFIG_INT_TYPE,rval,&cnt);
+    //      if (cnt>0)
+    //      {
+    //         extern ushort wrap_joy_type;
+    //         extern ushort high_joy_flags;
+    //         joy_type=rval[0];
+    //         wrap_joy_type  = joy_type & ~JOY_NO_NGP;
+    //         high_joy_flags = joy_type & JOY_NO_NGP;
+    //      }
+    //   }
+    //   if (joystick_count=joy_init(joy_type))
+    //   {
+    //#ifdef PLAYTEST
+    //      mprintf("Got %d joystick pots\n",joystick_count);
+    //#endif
+    //      hotkey_add(ALT('j'),DEMO_CONTEXT|EDIT_CONTEXT,recenter_joystick,NULL);
+    //   }
+    //
 }
+*/
 
 void shutdown_input(void) {
     hotkey_shutdown();
@@ -2273,8 +2275,7 @@ uchar view3d_mouse_handler(uiMouseEvent *ev, LGRegion *r, view3d_data *data) {
     }
 
     if (ev->action & (MOUSE_WHEELUP | MOUSE_WHEELDN)) {
-        extern uchar cycle_weapons_func(ushort keycode, ulong context, int data);
-        cycle_weapons_func(0, 0, ev->action & MOUSE_WHEELUP ? -1 : 1);
+        cycle_weapons_func(0, 0, (void *)(ev->action & MOUSE_WHEELUP ? -1 : 1));
     }
 
     // data->ldown = TRUE;
@@ -2290,47 +2291,39 @@ typedef struct _view3d_kdata {
     int maxctrl; // max control as affected by fatigue
 } view3d_kdata;
 
-#define FIRE_KEY KEY_ENTER // KLC for PC was KEY_ENTER
+extern int FireKeys[]; //see MacSrc/Prefs.c
 
-uchar view3d_key_handler(uiCookedKeyEvent *ev, LGRegion *r, void *data) {
-    uchar retval = FALSE;
-    // KLC   static uchar fire_key_down = FALSE;
-    LGPoint evp;
+uchar view3d_key_handler(uiCookedKeyEvent *ev, LGRegion *r, void *data)
+{
+  int i, detect = 0, fire_pressed = 0;
 
-    if (ev->code == DOWN(FIRE_KEY)) // If fire key was pressed
+  i = 0;
+  while (FireKeys[i] != 0)
+  {
+    if (ev->code == FireKeys[i]) detect = 1;
+    if (ev->code == (FireKeys[i] | KB_FLAG_DOWN)) {detect = 1; fire_pressed = 1; break;}
+    i++;
+  }
+  if (!detect) return FALSE;
+
+  if (fire_pressed)
+  {
+    if (weapon_button_up) // if we haven't fired already
     {
-        if (weapon_button_up) // and we haven't fired already
-        {
-            evp = ev->pos;
-            ss_point_convert(&(evp.x), &(evp.y), FALSE);
-            fire_player_weapon(&evp, r, !fire_slam);
-            fire_slam = TRUE;
-            weapon_button_up = FALSE;
-        }
-        /*
-              evp = ev->pos;
-        #ifdef SVGA_SUPPORT
-              ss_point_convert(&(evp.x),&(evp.y),FALSE);
-        #endif
-        //temp      fire_player_weapon(&evp,r,!fire_key_down);
-              fire_player_weapon(&evp, r, !fire_slam);
-        //      view3d_constrain_mouse(_current_view,FIREKEY_CONSTRAIN_BIT);
-        //KLC      retval = fire_key_down = TRUE;
-              fire_slam = TRUE;
-           }
-           else if (ev->code == FIRE_KEY)
-           {
-        //      view3d_unconstrain_mouse(FIREKEY_CONSTRAIN_BIT);
-              retval = TRUE;
-        //KLC      fire_key_down = FALSE;
-              fire_slam = FALSE;
-        */
-    } else if (ev->code == FIRE_KEY) {
-        weapon_button_up = TRUE;
-        fire_slam = FALSE;
+      LGPoint evp = ev->pos;
+      ss_point_convert(&(evp.x), &(evp.y), FALSE);
+      fire_player_weapon(&evp, r, !fire_slam);
+      fire_slam = TRUE;
+      weapon_button_up = FALSE;
     }
+  }
+  else
+  {
+    weapon_button_up = TRUE;
+    fire_slam = FALSE;
+  }
 
-    return retval;
+  return FALSE;
 }
 
 #ifdef NOT_YET // KLC - for VR headsets

--- a/src/GameSrc/movekeys.c
+++ b/src/GameSrc/movekeys.c
@@ -31,235 +31,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "physics.h"
 #include "gamesys.h"
 #include "weapons.h"
+#include "movekeys.h"
 
-// Here we go, it's gruesome keyboard polling code.
 
-// -------
-// DEFINES
-// -------
 
-#define KBCOUNTRY_CFG "country"
+#define KEYBD_CONTROL_BANK  1
 
-#define KEYBD_CONTROL_BANK 1
-#define MOTION_RUN_KEY 'S'
 
-#define CTRL KB_FLAG_CTRL
-#define ALT KB_FLAG_ALT
-#define SHF KB_FLAG_SHIFT
 
-// Ok, here's a bunch of scan codes.
-// KLC - these have all been changed for the Mac keyboards
-#define _Q_      0x0C // q
-#define _W_      0x0D // w
-#define _E_      0x0E // e
-#define _D_      0x02 // d
-#define _A_      0x00 // a
-#define _S_      0x01 // s
-#define _Z_      0x06 // z
-#define _X_      0x07 // x
-#define _C_      0x08 // c
-#define _UP_     0x7E // uparrow
-#define _LEFT_   0x7B // leftarrow
-#define _DOWN_   0x7D // downarrow
-#define _RIGHT_  0x7C // rightarrow
-#define _PGUP2_  0x5C // keypad pgup
-#define _HOME2_  0x59 // keypad home
-#define _END2_   0x53 // keypad End
-#define _PGDN2_  0x55 // keypad pgdn
-#define _PAD5_   0x57 // keypad 5
-#define _UP2_    0x5B // second uparrow
-#define _LEFT2_  0x56 // second leftarrow
-#define _DOWN2_  0x54 // second downarrow
-#define _RIGHT2_ 0x58 // second rightarrow
-#define _SPACE_  0x31 // spacebar
-#define _ENTER2_ 0x4C // keypad enter
-#define _ENTER_  0x24 // enter
-#define _R_      0x0F // r
-#define _V_      0x09 // v
-#define _J_      0x26 // j
+//filled in MacSrc/Prefs.c
+MOVE_KEYBIND      MoveKeybinds[MAX_MOVE_KEYBINDS+1];
+MOVE_KEYBIND MoveCyberKeybinds[MAX_MOVE_KEYBINDS+1];
 
-// Ok, these are cooked keycodes for all the motion keys.
-// If you want to add a motion key for a motion function
-// that already exists, just add it to the appropriate #define.
-// Otherwise, create a new #define, and a new case in the parse_motion_key
-// switch statement.
+static uchar motion_key_scancodes[256+1];
+static byte poll_controls[6];
 
-#define RUN_CASES     \
-    case _UP_ | SHF:  \
-    case _UP_ | ALT:  \
-    case _UP2_ | SHF: \
-    case _UP2_ | ALT:
-#define JOG_THRUST_CASES case _W_:
-#define RUN_THRUST_CASES case _W_ | SHF:
-#define JOG_CASES \
-    case _UP_:    \
-    case _UP2_:
-#define BACK_CASES      \
-    case _S_:           \
-    case _S_ | SHF:     \
-    case _DOWN_:        \
-    case _DOWN2_:       \
-    case _DOWN_ | ALT:  \
-    case _DOWN2_ | ALT: \
-    case _DOWN_ | SHF:  \
-    case _DOWN2_ | SHF:
-#define ROTL_CASES \
-    case _LEFT_:   \
-    case _Z_:      \
-    case _LEFT2_:
-#define ROTL_FAST_CASES \
-    case _Z_ | SHF:     \
-    case _LEFT_ | SHF:  \
-    case _LEFT2_ | SHF:
-#define ROTR_CASES \
-    case _RIGHT_:  \
-    case _C_:      \
-    case _RIGHT2_:
-#define ROTR_FAST_CASES \
-    case _RIGHT_ | SHF: \
-    case _C_ | SHF:     \
-    case _RIGHT2_ | SHF:
-#define SLIDL_CASES    \
-    case _A_:          \
-    case _LEFT_ | ALT: \
-    case _END2_:       \
-    case _A_ | SHF:    \
-    case _LEFT2_ | ALT:
-#define SLIDR_CASES      \
-    case _D_:            \
-    case _RIGHT_ | ALT:  \
-    case _RIGHT2_ | ALT: \
-    case _PGDN2_:        \
-    case _D_ | SHF:
-#define LEANL_CASES      \
-    case _Q_:            \
-    case _LEFT_ | CTRL:  \
-    case _LEFT2_ | CTRL: \
-    case _Q_ | SHF:
-#define LEANR_CASES       \
-    case _E_:             \
-    case _RIGHT_ | CTRL:  \
-    case _RIGHT2_ | CTRL: \
-    case _E_ | SHF:
-#define LEANUP_CASES \
-    case _X_:        \
-    case _X_ | CTRL: \
-    case _X_ | ALT:  \
-    case _X_ | SHF:
-#define JUMP_CASES       \
-    case _J_:            \
-    case _J_ | SHF:      \
-    case _SPACE_ | SHF:  \
-    case _SPACE_ | ALT:  \
-    case _SPACE_ | CTRL: \
-    case _SPACE_:
-#define EYEUP_CASES    \
-    case _R_:          \
-    case _R_ | CTRL:   \
-    case _UP_ | CTRL:  \
-    case _UP2_ | CTRL: \
-    case _R_ | SHF:
-#define EYEDOWN_CASES    \
-    case _V_:            \
-    case _V_ | CTRL:     \
-    case _DOWN_ | CTRL:  \
-    case _DOWN2_ | CTRL: \
-    case _V_ | SHF:
+extern Boolean gKeypadOverride;
 
-#define FORW_L_CASES case _HOME2_:
-#define FORW_R_CASES case _PGUP2_:
 
-// -----------------
-// CYBERSPACE CONTROLS
-// -----------------
-#define THRUST_CASES \
-    case _S_:        \
-    case _S_ | SHF:  \
-    case _PAD5_:     \
-// KLC     case _SPACE_:
-#define PITCH_UP_CASES \
-    case _W_:          \
-    case _W_ | SHF:    \
-    case _UP_:         \
-    case _UP_ | SHF:   \
-    case _UP_ | CTRL:  \
-    case _UP_ | ALT:   \
-    case _UP2_:        \
-    case _UP2_ | SHF:  \
-    case _UP2_ | CTRL: \
-    case _UP2_ | ALT:
-#define PITCH_DN_CASES   \
-    case _X_:            \
-    case _X_ | SHF:      \
-    case _DOWN_:         \
-    case _DOWN_ | SHF:   \
-    case _DOWN_ | CTRL:  \
-    case _DOWN_ | ALT:   \
-    case _DOWN2_:        \
-    case _DOWN2_ | SHF:  \
-    case _DOWN2_ | CTRL: \
-    case _DOWN2_ | ALT:
-#define BANK_L_CASES    \
-    case _A_:           \
-    case _A_ | SHF:     \
-    case _LEFT2_:       \
-    case _LEFT2_ | SHF: \
-    case _LEFT2_ | ALT: \
-    case _LEFT2_ | CTRL:
-#define BANK_R_CASES      \
-    case _D_:             \
-    case _D_ | SHF:       \
-    case _RIGHT2_:        \
-    case _RIGHT2_ | SHF:  \
-    case _RIGHT2_ | CTRL: \
-    case _RIGHT2_ | ALT:
-#define UP_L_CASES       \
-    case _HOME2_:        \
-    case _HOME2_ | SHF:  \
-    case _HOME2_ | CTRL: \
-    case _HOME2_ | ALT:
-#define UP_R_CASES       \
-    case _PGUP2_:        \
-    case _PGUP2_ | SHF:  \
-    case _PGUP2_ | CTRL: \
-    case _PGUP2_ | ALT:
-#define DOWN_L_CASES    \
-    case _END2_:        \
-    case _END2_ | SHF:  \
-    case _END2_ | CTRL: \
-    case _END2_ | ALT:
-#define DOWN_R_CASES     \
-    case _PGDN2_:        \
-    case _PGDN2_ | SHF:  \
-    case _PGDN2_ | CTRL: \
-    case _PGDN2_ | ALT:
-#define ROLL_L_CASES \
-    case _Q_:        \
-    case _Q_ | SHF:  \
-    case _Z_:        \
-    case _Z_ | SHF:
-#define ROLL_R_CASES \
-    case _E_:        \
-    case _E_ | SHF:  \
-    case _C_:        \
-    case _C_ | SHF:
 
-#define SLOW_TURN_RATE (CONTROL_MAX_VAL / 2)
-
-#define LEAN_CONTROL_NUM CONTROL_XZROT
-#define EYE_CONTROL_NUM CONTROL_YZROT
-
-// -------
-// GLOBALS
-// -------
-
-extern uchar motion_key_scancodes[]; // KBC_NONE terminated scancodes
-
-// ---------
-// INFERNALS
-// ---------
-uchar parse_motion_key(ushort keycode, short *cnum, short *cval);
-uchar parse_motion_key_cyber(ushort keycode, short *cnum, short *cval);
+uchar parse_motion_key(ushort code, short *cnum, short *cval);
+uchar parse_motion_key_cyber(ushort code, short *cnum, short *cval);
 void init_motion_polling(void);
 void setup_motion_polling(void);
 void process_motion_keys(void);
@@ -267,265 +59,320 @@ uchar motion_keycheck_handler(uiEvent *ev, LGRegion *, void *);
 
 extern void physics_set_relax(int axis, uchar relax);
 
-static byte poll_controls[6];
 
-// Hey, this deals with motion keys
-uchar parse_motion_key(ushort keycode, short *cnum, short *cval) {
-    *cnum = -1;
-    *cval = 0;
-    switch (keycode) {
-        RUN_THRUST_CASES
-        RUN_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        break;
-        JOG_THRUST_CASES
-        JOG_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL / 2;
-        break;
 
-        ROTL_FAST_CASES
-        *cval = -(CONTROL_MAX_VAL - SLOW_TURN_RATE);
-    turn_l:
-        ROTL_CASES
-        *cnum = CONTROL_XYROT;
-        *cval += -SLOW_TURN_RATE;
-        break;
+uchar parse_motion_key(ushort code, short *cnum, short *cval)
+{
+  int i = 0, move = -1;
 
-        ROTR_FAST_CASES
-        *cval = (CONTROL_MAX_VAL - SLOW_TURN_RATE);
-    turn_r:
-        ROTR_CASES
-        *cnum = CONTROL_XYROT;
-        *cval += SLOW_TURN_RATE;
-        break;
+  *cnum = -1;
+  *cval = 0;
 
-        BACK_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = -CONTROL_MAX_VAL / 2;
-        break;
-        SLIDL_CASES
-        *cnum = CONTROL_XVEL;
-        *cval = -CONTROL_MAX_VAL / 2;
-        break;
-        SLIDR_CASES
-        *cnum = CONTROL_XVEL;
-        *cval = CONTROL_MAX_VAL / 2;
-        break;
-        JUMP_CASES
-        *cnum = CONTROL_ZVEL;
-        *cval = MAX_JUMP_CONTROL;
-        break;
-        LEANUP_CASES
-        *cnum = LEAN_CONTROL_NUM;
-        *cval = 0;
-        physics_set_relax(*cnum, TRUE);
-        break;
-        LEANL_CASES
-        *cval = -CONTROL_MAX_VAL;
-        *cnum = LEAN_CONTROL_NUM;
-        physics_set_relax(*cnum, TRUE);
-        break;
-        LEANR_CASES
-        *cval = CONTROL_MAX_VAL;
-        *cnum = LEAN_CONTROL_NUM;
-        physics_set_relax(*cnum, TRUE);
-        break;
-        EYEUP_CASES
-        *cnum = EYE_CONTROL_NUM;
-        *cval = CONTROL_MAX_VAL;
-        //      physics_setq_relax(*cnum,TRUE);
-        break;
-        EYEDOWN_CASES
-        *cnum = EYE_CONTROL_NUM;
-        *cval = -CONTROL_MAX_VAL;
-        //      physics_set_relax(*cnum,TRUE);
-        break;
-        FORW_L_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        *cval = 0;
-        goto turn_l;
-        FORW_R_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        *cval = 0;
-        goto turn_r;
-    }
-    return *cnum != -1;
+  while (MoveKeybinds[i].code != 255)
+  {
+    if (code == MoveKeybinds[i].code) {move = MoveKeybinds[i].move; break;}
+    i++;
+  }
+
+  switch (move)
+  {
+    case M_RUNFORWARD:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_FORWARD:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_FASTTURNLEFT:
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_TURNLEFT:
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_FASTTURNRIGHT:
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_TURNRIGHT:
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_BACK:
+      *cnum = CONTROL_YVEL;
+      *cval = -CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_SLIDELEFT:
+      *cnum = CONTROL_XVEL;
+      *cval = -CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_SLIDERIGHT:
+      *cnum = CONTROL_XVEL;
+      *cval = CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_JUMP:
+      *cnum = CONTROL_ZVEL;
+      *cval = MAX_JUMP_CONTROL;
+    break;
+
+    case M_LEANUP:
+      *cnum = CONTROL_XZROT;
+      *cval = 0;
+      physics_set_relax(*cnum, TRUE);
+    break;
+
+    case M_LEANLEFT:
+      *cnum = CONTROL_XZROT;
+      *cval = -CONTROL_MAX_VAL;
+      physics_set_relax(*cnum, TRUE);
+    break;
+
+    case M_LEANRIGHT:
+      *cnum = CONTROL_XZROT;
+      *cval = CONTROL_MAX_VAL;
+      physics_set_relax(*cnum, TRUE);
+    break;
+
+    case M_LOOKUP:
+      *cnum = CONTROL_YZROT;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_LOOKDOWN:
+      *cnum = CONTROL_YZROT;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_RUNLEFT:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL / 2;
+    break;
+
+    case M_RUNRIGHT:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL / 2;
+    break;
+  }
+
+  return *cnum != -1;
 }
 
-uchar parse_motion_key_cyber(ushort keycode, short *cnum, short *cval) {
-    keycode &= ~KB_FLAG_2ND;
-    *cnum = -1;
-    *cval = 0;
-    switch (keycode) {
-        THRUST_CASES
-        *cnum = CONTROL_ZVEL;
-        *cval = MAX_JUMP_CONTROL;
-        break;
 
-        PITCH_UP_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = -CONTROL_MAX_VAL;
-        break;
-    bank_l:
-        BANK_L_CASES
-        *cnum = CONTROL_XYROT;
-        *cval = -CONTROL_MAX_VAL;
-        break;
-    bank_r:
-        BANK_R_CASES
-        *cnum = CONTROL_XYROT;
-        *cval = CONTROL_MAX_VAL;
-        break;
-        UP_L_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = -CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        goto bank_l;
-        UP_R_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = -CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        goto bank_r;
-        DOWN_R_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        goto bank_r;
-        DOWN_L_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        if (abs(poll_controls[*cnum]) < abs(*cval))
-            poll_controls[*cnum] = *cval;
-        goto bank_l;
-        PITCH_DN_CASES
-        *cnum = CONTROL_YVEL;
-        *cval = CONTROL_MAX_VAL;
-        break;
-        ROLL_L_CASES
-        *cnum = CONTROL_XVEL;
-        *cval = -CONTROL_MAX_VAL;
-        break;
-        ROLL_R_CASES
-        *cnum = CONTROL_XVEL;
-        *cval = CONTROL_MAX_VAL;
-        break;
-    }
-    return *cnum != -1;
+
+uchar parse_motion_key_cyber(ushort code, short *cnum, short *cval)
+{
+  int i = 0, move = -1;
+
+  code &= ~KB_FLAG_2ND;
+
+  *cnum = -1;
+  *cval = 0;
+
+  while (MoveCyberKeybinds[i].code != 255)
+  {
+    if (code == MoveCyberKeybinds[i].code) {move = MoveCyberKeybinds[i].move; break;}
+    i++;
+  }
+
+  switch (move)
+  {
+    case M_THRUST:
+      *cnum = CONTROL_ZVEL;
+      *cval = MAX_JUMP_CONTROL;
+    break;
+
+    case M_CLIMB:
+      *cnum = CONTROL_YVEL;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_BANKLEFT:
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_BANKRIGHT:
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_DIVE:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_ROLLRIGHT:
+      *cnum = CONTROL_XVEL;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_ROLLLEFT:
+      *cnum = CONTROL_XVEL;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_CLIMBLEFT:
+      *cnum = CONTROL_YVEL;
+      *cval = -CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+
+    case M_CLIMBRIGHT:
+      *cnum = CONTROL_YVEL;
+      *cval = -CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_DIVERIGHT:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = CONTROL_MAX_VAL;
+    break;
+
+    case M_DIVELEFT:
+      *cnum = CONTROL_YVEL;
+      *cval = CONTROL_MAX_VAL;
+      if (abs(poll_controls[*cnum]) < abs(*cval)) poll_controls[*cnum] = *cval;
+      *cnum = CONTROL_XYROT;
+      *cval = -CONTROL_MAX_VAL;
+    break;
+  }
+
+  return *cnum != -1;
 }
 
-// ---------
-// EXTERNALS
-// ---------
 
-extern uchar fire_slam;
 
-void init_motion_polling(void) {
-    uiSetKeyboardPolling(motion_key_scancodes);
-    /* KLC no longer needed
-       int i,cnt;
-       cnt = 1;
-       config_get_value(KBCOUNTRY_CFG,CONFIG_INT_TYPE,&i,&cnt);
-       if (cnt > 0)
-          kb_set_country(i);
-    */
-}
+//always poll these codes; see init_motion_polling() below
+static int always_motion_poll[] =
+{
+  0x7E, //up arrow
+  0x7D, //down arrow
+  0x7B, //left arrow
+  0x7C, //right arrow
+  0x59, //keypad home
+  0x5B, //keypad up
+  0x5C, //keypad pgup
+  0x56, //keypad left
+  0x57, //keypad 5
+  0x58, //keypad right
+  0x53, //keypad end
+  0x54, //keypad down
+  0x55, //keypad pgdn
+  0x4C, //keypad enter
+  0x24, //enter
 
-void setup_motion_polling(void) { LG_memset(poll_controls, 0, sizeof(poll_controls)); }
-
-void process_motion_keys(void) {
-    physics_set_player_controls(KEYBD_CONTROL_BANK, poll_controls[0], poll_controls[1], poll_controls[2],
-                                poll_controls[3], poll_controls[4], poll_controls[5]);
-}
-
-extern Boolean gKeypadOverride;
-
-uchar motion_keycheck_handler(uiEvent *ev, LGRegion *r, void *data) {
-    uiPollKeyEvent *ke = (uiPollKeyEvent *)ev;
-
-    // KLC - For Mac version, we'll cook our own, since we have the modifier information.
-    ushort cooked = ke->scancode | ke->mods;
-
-    short cnum, cval;
-
-    int moveOK = TRUE;
-
-    /* KLC - this doesn't appear to help any
-            // Check for firing weapon first (if it hasn't fired already).
-            if (ke->scancode == _SPACE_ || ke->scancode == _ENTER_ || ke->scancode == _ENTER2_)
-            {
-                    if (!fire_slam)
-                    {
-                            extern LGRegion* _current_view;
-                            LGPoint pos;
-                            ui_mouse_get_xy(&pos.x,&pos.y);
-                     fire_player_weapon(&pos, _current_view, !fire_slam);
-                    fire_slam = TRUE;
-                }
-            }
-
-            // Check for motion keys
-            else
-    */
-    if (gKeypadOverride) // if a keypad is showing
-    {
-        if (ke->scancode >= 0x52 && ke->scancode <= 0x5C) // and a keypad number was entered,
-            moveOK = FALSE;                               // don't move.
-    }
-
-    if (moveOK) {
-        if (global_fullmap->cyber && parse_motion_key_cyber(cooked, &cnum, &cval) ||
-            parse_motion_key(cooked, &cnum, &cval)) {
-            if (abs(poll_controls[cnum]) < abs(cval))
-                poll_controls[cnum] = cval;
-        }
-    }
-    return TRUE;
-}
-
-// Here is the list of SCAN CODES for all the motion keys.
-// If you want to add a motion key, you MUST PUT ITS SCANCODE HERE
-// or else the key will not get polled.
-
-uchar motion_key_scancodes[] = {
-    _Q_,      // q
-    _W_,      // w
-    _E_,      // e
-    _D_,      // d
-    _A_,      // a
-    _S_,      // s
-    _Z_,      // z
-    _X_,      // x
-    _C_,      // c
-    _UP_,     // uparrow
-    _LEFT_,   // leftarrow
-    _DOWN_,   // downarrow
-    _RIGHT_,  // rightarrow
-    _PGUP2_,  // keypad pgup
-    _HOME2_,  // keypad home
-    _END2_,   // End
-    _PGDN2_,  // keypad pgdn
-    _PAD5_,   // keypad 5
-    _UP2_,    // second uparrow
-    _LEFT2_,  // second leftarrow
-    _DOWN2_,  // second downarrow
-    _RIGHT2_, // second rightarrow
-    _SPACE_,  // spacebar
-    _ENTER2_, // keypad enter
-    _ENTER_,  // enter
-    _R_,      // r
-    _V_,      // v
-    _J_,      // j
-
-    KBC_NONE, // end of list
+  255   //signal end of list
 };
+
+
+
+void init_motion_polling(void)
+{
+  int i, j = 0, code;
+  uchar used[256];
+
+  //keep track of which codes have already been added
+  memset(used, 0, 256);
+
+  //add move keybinds to list of scancodes to poll
+  i = 0;
+  while (MoveKeybinds[i].code != 255)
+  {
+    code = MoveKeybinds[i].code & 255;
+    if (!used[code]) {used[code] = 1; motion_key_scancodes[j++] = code;}
+    i++;
+  }
+
+  //add move cyber keybinds to list of scancodes to poll
+  i = 0;
+  while (MoveCyberKeybinds[i].code != 255)
+  {
+    code = MoveCyberKeybinds[i].code & 255;
+    if (!used[code]) {used[code] = 1; motion_key_scancodes[j++] = code;}
+    i++;
+  }
+
+  //always poll these codes, so add them if they weren't added already
+  i = 0;
+  while (always_motion_poll[i] != 255)
+  {
+    code = always_motion_poll[i];
+    if (!used[code]) {used[code] = 1; motion_key_scancodes[j++] = code;}
+    i++;
+  }
+
+  motion_key_scancodes[j] = KBC_NONE; //signal end of list
+
+  uiSetKeyboardPolling(motion_key_scancodes);
+}
+
+
+
+void setup_motion_polling(void)
+{
+  LG_memset(poll_controls, 0, sizeof(poll_controls));
+}
+
+
+
+void process_motion_keys(void)
+{
+  physics_set_player_controls(KEYBD_CONTROL_BANK, poll_controls[0], poll_controls[1], poll_controls[2],
+                              poll_controls[3], poll_controls[4], poll_controls[5]);
+}
+
+
+
+uchar motion_keycheck_handler(uiEvent *ev, LGRegion *r, void *data)
+{
+  uiPollKeyEvent *ke = (uiPollKeyEvent *)ev;
+
+  // KLC - For Mac version, we'll cook our own, since we have the modifier information.
+  ushort cooked = ke->scancode | ke->mods;
+
+  short cnum, cval;
+
+  int moveOK = TRUE;
+
+  if (gKeypadOverride) // if a keypad is showing
+  {
+    if (ke->scancode >= 0x52 && ke->scancode <= 0x5C) // and a keypad number was entered,
+        moveOK = FALSE;                               // don't move.
+  }
+
+  if (moveOK)
+  {
+    if (global_fullmap->cyber && parse_motion_key_cyber(cooked, &cnum, &cval) ||
+        parse_motion_key(cooked, &cnum, &cval))
+    {
+      if (abs(poll_controls[cnum]) < abs(cval))
+        poll_controls[cnum] = cval;
+    }
+  }
+
+  return TRUE;
+}

--- a/src/Libraries/INPUT/Source/kbcook.c
+++ b/src/Libraries/INPUT/Source/kbcook.c
@@ -64,6 +64,9 @@ errtype kb_cook(kbs_event ev, ushort *cooked, uchar *results)
 	
 	*cooked |= (short)ev.state << KB_DOWN_SHF; // Add in the key-down state.
 
+    //text input events are used to get printable characters (see sdl_events.c)
+    //note that text input events don't work for ctrl'd or alt'd keys
+
 	if (ev.modifiers & KB_MOD_CTRL)		// If command-key was down,
 		*cooked |= KB_FLAG_CTRL;	// simulate a control key
 		
@@ -71,30 +74,8 @@ errtype kb_cook(kbs_event ev, ushort *cooked, uchar *results)
 		*cooked |= KB_FLAG_SHIFT;
 		
 	if (ev.modifiers & KB_MOD_ALT)		// If option-key was down,
-	{								// simulate an alt key.
-		long	tk = 0;
-		uint32_t	state = 0;
-		
-		// Unfortunately, option-key changes the character that was
-		// pressed.  So we need to find out what the unmodified
-		// character is.
-#if 1
-		STUB_ONCE("TODO: Figure out what this should do and do it with SDL.."); // TODO
-#else
-		Handle	kHdl;
-		// Note: this apprently gets the keyboard layout from MacOS
-		//       not sure we can do that with SDL, we should try to use SDL_TEXTINPUT events..
-		kHdl = GetIndResource('KCHR', 1);
-		HLock(kHdl);
-		tk = KeyTranslate(*kHdl, ev.code, &state);
-		HUnlock(kHdl);
-#endif
-		
-		// We've got the character, so or it into the "cooked" short.
-		*cooked &= 0xFF00;
-		*cooked |= (ushort)(tk & 0x00FF) | KB_FLAG_ALT;
-	}
-		
+		*cooked |= KB_FLAG_ALT;         // simulate an alt key.
+
 	return OK;
 /*
    ushort flags = KB_CNV(ev.code,0);

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -311,10 +311,37 @@ void pump_events(void)
 					//printf("ev.key.keysym.sym: %x\n", ev.key.keysym.sym);
 
 					// FIXME: this is hacky, see comment in SDL_TEXTINPUT below..
-					if(ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= '~')
+					if(ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= 127)
 						keyEvent.ascii = ev.key.keysym.sym;
 					else
-						keyEvent.ascii = 0;
+                    {
+                        keyEvent.ascii = 0;
+
+                        //use these invented "ascii" codes for hotkey system
+                        //see MacSrc/Prefs.c
+                        switch (ev.key.keysym.sym)
+                        {
+                            case SDLK_F1:          keyEvent.ascii = 128 +  0; break;
+                            case SDLK_F2:          keyEvent.ascii = 128 +  1; break;
+                            case SDLK_F3:          keyEvent.ascii = 128 +  2; break;
+                            case SDLK_F4:          keyEvent.ascii = 128 +  3; break;
+                            case SDLK_F5:          keyEvent.ascii = 128 +  4; break;
+                            case SDLK_F6:          keyEvent.ascii = 128 +  5; break;
+                            case SDLK_F7:          keyEvent.ascii = 128 +  6; break;
+                            case SDLK_F8:          keyEvent.ascii = 128 +  7; break;
+                            case SDLK_F9:          keyEvent.ascii = 128 +  8; break;
+                            case SDLK_F10:         keyEvent.ascii = 128 +  9; break;
+                            case SDLK_F11:         keyEvent.ascii = 128 + 10; break;
+                            case SDLK_F12:         keyEvent.ascii = 128 + 11; break;
+                            case SDLK_KP_DIVIDE:   keyEvent.ascii = 128 + 12; break;
+                            case SDLK_KP_MULTIPLY: keyEvent.ascii = 128 + 13; break;
+                            case SDLK_KP_MINUS:    keyEvent.ascii = 128 + 14; break;
+                            case SDLK_KP_PLUS:     keyEvent.ascii = 128 + 15; break;
+                            case SDLK_KP_ENTER:    keyEvent.ascii = 128 + 16; break;
+                            case SDLK_KP_DECIMAL:  keyEvent.ascii = 128 + 17; break;
+                            case SDLK_KP_0:        keyEvent.ascii = 128 + 18; break;
+                        }
+                    }
 
 					keyEvent.modifiers = 0;
 					Uint16 mod = ev.key.keysym.mod;

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -175,22 +175,26 @@ static uchar sdlKeyCodeToSSHOCKkeyCode(SDL_Keycode kc)
 		case SDLK_KP_8 : return 0x5B; //  kVK_ANSI_Keypad8 = 0x5B, aka _UP2_
 		case SDLK_KP_9 : return 0x5C; //  kVK_ANSI_Keypad9 = 0x5C, aka _PGUP2_
 
-		// keycodes for keys that are independent of keyboard layout*/
+		// keycodes for keys that are independent of keyboard layout
 		case SDLK_RETURN : return 0x24; //  kVK_Return  = 0x24,
 		case SDLK_TAB : return 0x30; //  kVK_Tab     = 0x30,
 		case SDLK_SPACE : return 0x31; //  kVK_Space   = 0x31,
 		case SDLK_DELETE : return 0x33; //  kVK_Delete  = 0x33,
 		case SDLK_BACKSPACE : return 0x33; //  kVK_Delete  = 0x33,
 		case SDLK_ESCAPE : return 0x35; //  kVK_Escape  = 0x35,
-		case SDLK_LGUI : // fall-through
-		case SDLK_RGUI : return 0x37; //  kVK_Command = 0x37, // FIXME: I think command is the windows/meta key?
-		case SDLK_LSHIFT : return 0x38; //  kVK_Shift   = 0x38,
-		case SDLK_CAPSLOCK : return 0x39; //  kVK_CapsLock= 0x39,
-		case SDLK_LALT : return 0x3A; //  kVK_Option  = 0x3A, Option == Aalt
-		case SDLK_LCTRL : return 0x3B; //  kVK_Control = 0x3B,
-		case SDLK_RSHIFT : return 0x3C; //  kVK_RightShift  = 0x3C,
-		case SDLK_RALT : return 0x3D; //  kVK_RightOption = 0x3D,
-		case SDLK_RCTRL : return 0x3E; //  kVK_RightControl = 0x3E,
+
+        //    returning these is unnecessary and can cause keypresses to be missed
+        //    (esp keys with modifiers)
+		//case SDLK_LGUI : // fall-through
+		//case SDLK_RGUI : return 0x37; //  kVK_Command = 0x37, // FIXME: I think command is the windows/meta key?
+		//case SDLK_LSHIFT : return 0x38; //  kVK_Shift   = 0x38,
+		//case SDLK_CAPSLOCK : return 0x39; //  kVK_CapsLock= 0x39,
+		//case SDLK_LALT : return 0x3A; //  kVK_Option  = 0x3A, Option == Aalt
+		//case SDLK_LCTRL : return 0x3B; //  kVK_Control = 0x3B,
+		//case SDLK_RSHIFT : return 0x3C; //  kVK_RightShift  = 0x3C,
+		//case SDLK_RALT : return 0x3D; //  kVK_RightOption = 0x3D,
+		//case SDLK_RCTRL : return 0x3E; //  kVK_RightControl = 0x3E,
+
 		//case SDLK_ : return 0x3F; //  kVK_Function = 0x3F, // TODO: what's this?
 		case SDLK_F17 : return 0x40; //  kVK_F17 = 0x40,
 		case SDLK_VOLUMEUP : return 0x48; //  kVK_VolumeUp = 0x48,
@@ -403,83 +407,84 @@ void pump_events(void)
       case SDL_KEYDOWN:
       {
         uchar c = sdlKeyCodeToSSHOCKkeyCode(ev.key.keysym.sym);
-        if (c == KBC_NONE) break;
-
-        kbs_event keyEvent = { 0 };
-
-        keyEvent.code = c;
-        keyEvent.ascii = 0;
-        keyEvent.modifiers = 0;
-
-        //https://wiki.libsdl.org/SDLKeycodeLookup
-        //Keycodes for keys with printable characters are represented by the
-        //character byte in parentheses. Keycodes without character representations
-        //are determined by their scancode bitwise OR-ed with 1<<30 (0x40000000).
-
-        if (ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= 127)
-          keyEvent.ascii = ev.key.keysym.sym;
-        else
+        if (c != KBC_NONE)
         {
-          //use these invented "ascii" codes for hotkey system
-          //see MacSrc/Prefs.c
-          switch (ev.key.keysym.sym)
+          kbs_event keyEvent = { 0 };
+  
+          keyEvent.code = c;
+          keyEvent.ascii = 0;
+          keyEvent.modifiers = 0;
+  
+          //https://wiki.libsdl.org/SDLKeycodeLookup
+          //Keycodes for keys with printable characters are represented by the
+          //character byte in parentheses. Keycodes without character representations
+          //are determined by their scancode bitwise OR-ed with 1<<30 (0x40000000).
+  
+          if (ev.key.keysym.sym >= 0x08 && ev.key.keysym.sym <= 127)
+            keyEvent.ascii = ev.key.keysym.sym;
+          else
           {
-            case SDLK_F1:          keyEvent.ascii = 128 +  0; break;
-            case SDLK_F2:          keyEvent.ascii = 128 +  1; break;
-            case SDLK_F3:          keyEvent.ascii = 128 +  2; break;
-            case SDLK_F4:          keyEvent.ascii = 128 +  3; break;
-            case SDLK_F5:          keyEvent.ascii = 128 +  4; break;
-            case SDLK_F6:          keyEvent.ascii = 128 +  5; break;
-            case SDLK_F7:          keyEvent.ascii = 128 +  6; break;
-            case SDLK_F8:          keyEvent.ascii = 128 +  7; break;
-            case SDLK_F9:          keyEvent.ascii = 128 +  8; break;
-            case SDLK_F10:         keyEvent.ascii = 128 +  9; break;
-            case SDLK_F11:         keyEvent.ascii = 128 + 10; break;
-            case SDLK_F12:         keyEvent.ascii = 128 + 11; break;
-            case SDLK_KP_DIVIDE:   keyEvent.ascii = 128 + 12; break;
-            case SDLK_KP_MULTIPLY: keyEvent.ascii = 128 + 13; break;
-            case SDLK_KP_MINUS:    keyEvent.ascii = 128 + 14; break;
-            case SDLK_KP_PLUS:     keyEvent.ascii = 128 + 15; break;
-            case SDLK_KP_ENTER:    keyEvent.ascii = 128 + 16; break;
-            case SDLK_KP_DECIMAL:  keyEvent.ascii = 128 + 17; break;
-            case SDLK_KP_0:        keyEvent.ascii = 128 + 18; break;
+            //use these invented "ascii" codes for hotkey system
+            //see MacSrc/Prefs.c
+            switch (ev.key.keysym.sym)
+            {
+              case SDLK_F1:          keyEvent.ascii = 128 +  0; break;
+              case SDLK_F2:          keyEvent.ascii = 128 +  1; break;
+              case SDLK_F3:          keyEvent.ascii = 128 +  2; break;
+              case SDLK_F4:          keyEvent.ascii = 128 +  3; break;
+              case SDLK_F5:          keyEvent.ascii = 128 +  4; break;
+              case SDLK_F6:          keyEvent.ascii = 128 +  5; break;
+              case SDLK_F7:          keyEvent.ascii = 128 +  6; break;
+              case SDLK_F8:          keyEvent.ascii = 128 +  7; break;
+              case SDLK_F9:          keyEvent.ascii = 128 +  8; break;
+              case SDLK_F10:         keyEvent.ascii = 128 +  9; break;
+              case SDLK_F11:         keyEvent.ascii = 128 + 10; break;
+              case SDLK_F12:         keyEvent.ascii = 128 + 11; break;
+              case SDLK_KP_DIVIDE:   keyEvent.ascii = 128 + 12; break;
+              case SDLK_KP_MULTIPLY: keyEvent.ascii = 128 + 13; break;
+              case SDLK_KP_MINUS:    keyEvent.ascii = 128 + 14; break;
+              case SDLK_KP_PLUS:     keyEvent.ascii = 128 + 15; break;
+              case SDLK_KP_ENTER:    keyEvent.ascii = 128 + 16; break;
+              case SDLK_KP_DECIMAL:  keyEvent.ascii = 128 + 17; break;
+              case SDLK_KP_0:        keyEvent.ascii = 128 + 18; break;
+            }
           }
-        }
-
-        Uint16 mod = ev.key.keysym.mod;
-
-        if (mod & KMOD_SHIFT) keyEvent.modifiers |= KB_MOD_SHIFT;
-        if (mod & KMOD_CTRL ) keyEvent.modifiers |= KB_MOD_CTRL;
-        if (mod & KMOD_ALT  ) keyEvent.modifiers |= KB_MOD_ALT;
-
-        if (ev.key.state == SDL_PRESSED)
-        {
-          if (ev.key.keysym.sym == SDLK_RETURN && mod & KMOD_ALT)
-            {toggleFullScreen(); break;}
-
-          //handle non-printable or ctrl'd or alt'd keys here
-          //other cases are handled by text input event below
-          if (ev.key.keysym.sym < 32 || ev.key.keysym.sym > 126 || (mod & KMOD_CTRL) || (mod & KMOD_ALT))
+  
+          Uint16 mod = ev.key.keysym.mod;
+  
+          if (mod & KMOD_SHIFT) keyEvent.modifiers |= KB_MOD_SHIFT;
+          if (mod & KMOD_CTRL ) keyEvent.modifiers |= KB_MOD_CTRL;
+          if (mod & KMOD_ALT  ) keyEvent.modifiers |= KB_MOD_ALT;
+  
+          if (ev.key.state == SDL_PRESSED)
           {
-            keyEvent.state = KBS_DOWN;
+            if (ev.key.keysym.sym == SDLK_RETURN && mod & KMOD_ALT)
+              {toggleFullScreen(); break;}
+  
+            //handle non-printable or ctrl'd or alt'd keys here
+            //other cases are handled by text input event below
+            if (ev.key.keysym.sym < 32 || ev.key.keysym.sym > 126 || (mod & KMOD_CTRL) || (mod & KMOD_ALT))
+            {
+              keyEvent.state = KBS_DOWN;
+              addKBevent(&keyEvent);
+    
+              sshockKeyStates[c] = keyEvent.modifiers | KB_MOD_PRESSED;
+            }
+          }
+          else
+          {
+            //key up following text input event case below is handled here
+  
+            keyEvent.state = KBS_UP;
             addKBevent(&keyEvent);
-  
-            sshockKeyStates[c] = keyEvent.modifiers | KB_MOD_PRESSED;
+    
+            sshockKeyStates[c] = 0;
           }
-        }
-        else
-        {
-          //key up following text input event case below is handled here
-
-          keyEvent.state = KBS_UP;
-          addKBevent(&keyEvent);
-  
-          sshockKeyStates[c] = 0;
         }
 
         //hack to allow pressing shift after move key
         //sets all current shock states in array to shifted or non-shifted
-        if (c == 0x38 || c == 0x3C) //left or right shift
+        if (ev.key.keysym.sym == SDLK_LSHIFT || ev.key.keysym.sym == SDLK_RSHIFT)
         {
           int i;
           for (i=0; i<256; i++) if (sshockKeyStates[i])

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -439,7 +439,6 @@ extern uchar posture_hotkey_func(short keycode, ulong context, void *data);
 extern uchar toggle_mouse_look(short keycode, ulong context, void *data);
 extern uchar change_mode_func(short keycode, ulong context, void *data);
 extern uchar clear_fullscreen_func(short keycode, ulong context, void *data);
-extern uchar save_hotkey_func(short keycode, ulong context, void *data);
 extern uchar saveload_hotkey_func(short keycode, ulong context, void *data);
 extern uchar pause_game_func(short keycode, ulong context, void *data);
 extern uchar reload_weapon_hotkey(short keycode, ulong context, void *data);
@@ -496,7 +495,7 @@ HOTKEYLOOKUP HotKeyLookup[] =
   { "\"normal_view\"",      DEMO_CONTEXT, change_mode_func,       (void *)GAME_LOOP      , 0, CTRL('d'),     0 },
   { "\"map_view\"",         DEMO_CONTEXT, change_mode_func,       (void *)AUTOMAP_LOOP   , 0, CTRL('a'),     0 },
   { "\"clear_fullscreen\"", DEMO_CONTEXT, clear_fullscreen_func,  NULL                   , 0, DOWN(KEY_BS),  0 },
-  { "\"save_game\"",        DEMO_CONTEXT, save_hotkey_func,       NULL                   , 0, CTRL('s'),     0 },
+  { "\"save_game\"",        DEMO_CONTEXT, saveload_hotkey_func,   (void *)FALSE          , 0, CTRL('s'),     0 },
   { "\"load_game\"",        DEMO_CONTEXT, saveload_hotkey_func,   (void *)TRUE           , 0, CTRL('l'),     0 },
   { "\"pause\"",            DEMO_CONTEXT, pause_game_func,        (void *)TRUE           , 0, DOWN('p'),     0 },
   { "\"reload_weapon 1\"",  DEMO_CONTEXT, reload_weapon_hotkey,   (void *)1              , 0, CTRL(KEY_BS),  0 },

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //		System Shock - ©1994-1995 Looking Glass Technologies, Inc.
 //
 //		Prefs.c	-	Handles saving and loading preferences.
+//                  Also loads and sets default keybinds.
 //
 //====================================================================================
 
@@ -32,8 +33,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "popups.h"
 #include "olhext.h"
+#include "hotkey.h"
+#include "input.h"
+#include "mainloop.h"
+#include "movekeys.h"
 
-static void SetShockGlobals(void);
+//--------------------
+//  Filenames
+//--------------------
+static const char *PREFS_FILENAME = "prefs.txt";
+static const char *KEYBINDS_FILENAME = "keybinds.txt";
 
 //--------------------
 //  Globals
@@ -54,8 +63,6 @@ extern uchar curr_vol_lev;
 extern uchar curr_sfx_vol;
 extern uchar curr_alog_vol;
 
-static const char *PREFS_FILENAME = "prefs.txt";
-
 static const char *PREF_LANGUAGE     = "language";
 static const char *PREF_CAPTUREMOUSE = "capture-mouse";
 static const char *PREF_MUSIC_VOL    = "music-volume";
@@ -68,6 +75,8 @@ static const char *PREF_USE_OPENGL   = "use-opengl";
 static const char *PREF_LIN_SCALING  = "linear-scaling";
 static const char *PREF_ONSCR_HELP   = "onscreen-help";
 static const char *PREF_GAMMA        = "gamma";
+
+static void SetShockGlobals(void);
 
 //--------------------------------------------------------------------
 //	  Initialize the preferences to their default settings.
@@ -235,4 +244,901 @@ static void SetShockGlobals(void) {
     DoubleSize = (gShockPrefs.doResolution == 1); // Set this True for low-res.
     SkipLines = gShockPrefs.doUseQD;
     _fr_global_detail = gShockPrefs.doDetail;
+}
+
+
+
+//************************************************************************************
+
+
+
+//********
+//Keybinds
+//********
+
+
+
+//Note that Alt / Option (on Mac) modifier key won't work until it is implemented in sdl_events.c
+
+
+
+static struct {const char *s; int ch, code;} KeyName2ChCode[] =
+{
+  { "backspace ",       8, 0x33 },
+  { "tab ",             9, 0x30 },
+  { "enter ",          13, 0x24 },
+  { "escape ",         27, 0x35 },
+  { "space ",          32, 0x31 },
+  { "1 ",              49, 0x12 },
+  { "exclamation ",    33, 0x12 },
+  { "2 ",              50, 0x13 },
+  { "atsign ",         64, 0x13 },
+  { "3 ",              51, 0x14 },
+  { "numbersign ",     35, 0x14 },
+  { "4 ",              52, 0x15 },
+  { "dollar ",         36, 0x15 },
+  { "5 ",              53, 0x17 },
+  { "percent ",        37, 0x17 },
+  { "6 ",              54, 0x16 },
+  { "caret ",          94, 0x16 },
+  { "7 ",              55, 0x1A },
+  { "ampersand ",      38, 0x1A },
+  { "8 ",              56, 0x1C },
+  { "asterisk ",       42, 0x1C },
+  { "9 ",              57, 0x19 },
+  { "lparenthesis ",   40, 0x19 },
+  { "0 ",              48, 0x1D },
+  { "rparenthesis ",   41, 0x1D },
+  { "equals ",         61, 0x18 },
+  { "plus ",           43, 0x18 },
+  { "comma ",          44, 0x2B },
+  { "lessthan ",       60, 0x2B },
+  { "minus ",          45, 0x1B },
+  { "underscore ",     95, 0x1B },
+  { "period ",         46, 0x2F },
+  { "greaterthan ",    62, 0x2F },
+  { "slash ",          47, 0x2C },
+  { "questionmark ",   63, 0x2C },
+  { "quote ",          39, 0x27 },
+  { "doublequote ",    34, 0x27 },
+  { "semicolon ",      59, 0x29 },
+  { "colon ",          58, 0x29 },
+  { "a ",              97, 0x00 },
+  { "b ",              98, 0x0B },
+  { "c ",              99, 0x08 },
+  { "d ",             100, 0x02 },
+  { "e ",             101, 0x0E },
+  { "f ",             102, 0x03 },
+  { "g ",             103, 0x05 },
+  { "h ",             104, 0x04 },
+  { "i ",             105, 0x22 },
+  { "j ",             106, 0x26 },
+  { "k ",             107, 0x28 },
+  { "l ",             108, 0x25 },
+  { "m ",             109, 0x2E },
+  { "n ",             110, 0x2D },
+  { "o ",             111, 0x1F },
+  { "p ",             112, 0x23 },
+  { "q ",             113, 0x0C },
+  { "r ",             114, 0x0F },
+  { "s ",             115, 0x01 },
+  { "t ",             116, 0x11 },
+  { "u ",             117, 0x20 },
+  { "v ",             118, 0x09 },
+  { "w ",             119, 0x0D },
+  { "x ",             120, 0x07 },
+  { "y ",             121, 0x10 },
+  { "z ",             122, 0x06 },
+  { "A ",              65, 0x00 },
+  { "B ",              66, 0x0B },
+  { "C ",              67, 0x08 },
+  { "D ",              68, 0x02 },
+  { "E ",              69, 0x0E },
+  { "F ",              70, 0x03 },
+  { "G ",              71, 0x05 },
+  { "H ",              72, 0x04 },
+  { "I ",              73, 0x22 },
+  { "J ",              74, 0x26 },
+  { "K ",              75, 0x28 },
+  { "L ",              76, 0x25 },
+  { "M ",              77, 0x2E },
+  { "N ",              78, 0x2D },
+  { "O ",              79, 0x1F },
+  { "P ",              80, 0x23 },
+  { "Q ",              81, 0x0C },
+  { "R ",              82, 0x0F },
+  { "S ",              83, 0x01 },
+  { "T ",              84, 0x11 },
+  { "U ",              85, 0x20 },
+  { "V ",              86, 0x09 },
+  { "W ",              87, 0x0D },
+  { "X ",              88, 0x07 },
+  { "Y ",              89, 0x10 },
+  { "Z ",              90, 0x06 },
+  { "lbracket ",       91, 0x21 },
+  { "lcurbrace ",     123, 0x21 },
+  { "backslash ",      92, 0x2A },
+  { "vertline ",      124, 0x2A },
+  { "rbracket ",       93, 0x1E },
+  { "rcurbrace ",     125, 0x1E },
+  { "backquote ",      96, 0x32 },
+  { "tilde ",         126, 0x32 },
+  { "delete ",        127, 0x33 },
+
+  //use these invented "ascii" codes for hotkey system
+  //see sdl_events.c
+  { "f1 ",              128 +  0, 0x7A },
+  { "f2 ",              128 +  1, 0x78 },
+  { "f3 ",              128 +  2, 0x63 },
+  { "f4 ",              128 +  3, 0x76 },
+  { "f5 ",              128 +  4, 0x60 },
+  { "f6 ",              128 +  5, 0x61 },
+  { "f7 ",              128 +  6, 0x62 },
+  { "f8 ",              128 +  7, 0x64 },
+  { "f9 ",              128 +  8, 0x65 },
+  { "f10 ",             128 +  9, 0x6D },
+  { "f11 ",             128 + 10, 0x67 },
+  { "f12 ",             128 + 11, 0x6F },
+  { "keypad_divide ",   128 + 12, 0x4B },
+  { "keypad_multiply ", 128 + 13, 0x43 },
+  { "keypad_minus ",    128 + 14, 0x4E },
+  { "keypad_plus ",     128 + 15, 0x45 },
+  { "keypad_enter ",    128 + 16, 0x4C },
+  { "keypad_decimal ",  128 + 17, 0x41 },
+  { "keypad_0 ",        128 + 18, 0x52 },
+
+  //these have no invented "ascii" codes so they can't be used as hotkeys, only move keys
+  { "keypad_home ",     0, 0x59 },
+  { "keypad_up ",       0, 0x5B },
+  { "keypad_pgup ",     0, 0x5C },
+  { "keypad_left ",     0, 0x56 },
+  { "keypad_5 ",        0, 0x57 },
+  { "keypad_right ",    0, 0x58 },
+  { "keypad_end ",      0, 0x53 },
+  { "keypad_down ",     0, 0x54 },
+  { "keypad_pgdn ",     0, 0x55 },
+  { "home ",            0, 0x73 },
+  { "up ",              0, 0x7E },
+  { "pageup ",          0, 0x74 },
+  { "left ",            0, 0x7B },
+  { "right ",           0, 0x7C },
+  { "end ",             0, 0x77 },
+  { "down ",            0, 0x7D },
+  { "pagedown ",        0, 0x79 },
+
+  { NULL,               0,    0 }
+};
+
+
+
+//lower cases all characters in string p
+//also converts tabs to spaces
+static void LowerCaseInPlace(char *p)
+{
+  while (*p)
+  {
+    if (*p >= 'A' && *p <= 'Z') *p = *p - 'A' + 'a'; //convert upper to lower case
+    if (*p == '\t') *p = ' '; //convert tab to space
+    p++;
+  }
+}
+
+
+
+//*********************************
+//Set hotkey keybinds (see input.c)
+//Also handles fire keybinds
+//*********************************
+
+
+
+#ifdef AUDIOLOGS
+extern uchar audiolog_cancel_func(short keycode, ulong context, void *data);
+#endif
+extern uchar posture_hotkey_func(short keycode, ulong context, void *data);
+extern uchar toggle_mouse_look(short keycode, ulong context, void *data);
+extern uchar change_mode_func(short keycode, ulong context, void *data);
+extern uchar clear_fullscreen_func(short keycode, ulong context, void *data);
+extern uchar save_hotkey_func(short keycode, ulong context, void *data);
+extern uchar saveload_hotkey_func(short keycode, ulong context, void *data);
+extern uchar pause_game_func(short keycode, ulong context, void *data);
+extern uchar reload_weapon_hotkey(short keycode, ulong context, void *data);
+extern uchar select_grenade_hotkey(short keycode, ulong context, void *data);
+extern uchar toggle_olh_func(short keycode, ulong context, void *data);
+extern uchar select_drug_hotkey(short keycode, ulong context, void *data);
+extern uchar toggle_music_func(short keycode, ulong context, void *data);
+extern uchar MacQuitFunc(short keycode, ulong context, void *data);
+extern uchar cycle_weapons_func(short keycode, ulong context, void *data);
+extern uchar MacDetailFunc(short keycode, ulong context, void *data);
+extern uchar toggle_opengl_func(short keycode, ulong context, void *data);
+extern uchar arm_grenade_hotkey(short keycode, ulong context, void *data);
+extern uchar use_drug_hotkey(short keycode, ulong context, void *data);
+extern uchar hud_color_bank_cycle(short keycode, ulong context, void *data);
+extern uchar olh_overlay_func(short keycode, ulong context, void *data);
+extern uchar keypad_hotkey_func(short keycode, ulong context, void *data);
+extern uchar MacHelpFunc(short keycode, ulong context, void *data);
+extern uchar wrapper_options_func(short keycode, ulong context, void *data);
+extern uchar toggle_giveall_func(short keycode, ulong context, void *data);
+extern uchar toggle_physics_func(short keycode, ulong context, void *data);
+extern uchar toggle_up_level_func(short keycode, ulong context, void *data);
+extern uchar toggle_down_level_func(short keycode, ulong context, void *data);
+
+
+
+#define TAB_KEY    (KEY_TAB | KB_FLAG_DOWN)
+#define S_TAB_KEY  (KEY_TAB | KB_FLAG_DOWN | KB_FLAG_SHIFT)
+
+#define DOWN(x)    ((x) | KB_FLAG_DOWN)
+#define SHIFT(x)   (DOWN(x) | KB_FLAG_SHIFT)
+#define CTRL(x)    (DOWN(x) | KB_FLAG_CTRL)
+#define ALT(x)     (DOWN(x) | KB_FLAG_ALT)
+
+
+
+typedef struct HOTKEYLOOKUP_STRUCT
+{
+  const char *s; ulong contexts; hotkey_callback func; void *state; bool used; int def1, def2;
+} HOTKEYLOOKUP;
+
+
+
+HOTKEYLOOKUP HotKeyLookup[] =
+{
+//  name                    contexts      func                    state                 used  default key 1,2
+#ifdef AUDIOLOGS
+  { "\"audiolog_cancel\"",  DEMO_CONTEXT, audiolog_cancel_func,   NULL                   , 0, CTRL('.'),     0 },
+#endif
+  { "\"stand\"",            DEMO_CONTEXT, posture_hotkey_func,    (void *)0              , 0, DOWN('t'), SHIFT('t') },
+  { "\"crouch\"",           DEMO_CONTEXT, posture_hotkey_func,    (void *)1              , 0, DOWN('g'), SHIFT('g') },
+  { "\"prone\"",            DEMO_CONTEXT, posture_hotkey_func,    (void *)2              , 0, DOWN('b'), SHIFT('b') },
+  { "\"toggle_freelook\"",  DEMO_CONTEXT, toggle_mouse_look,      (void *)TRUE           , 0, DOWN('f'),     0 },
+  { "\"full_view\"",        DEMO_CONTEXT, change_mode_func,       (void *)FULLSCREEN_LOOP, 0, CTRL('f'),     0 },
+  { "\"normal_view\"",      DEMO_CONTEXT, change_mode_func,       (void *)GAME_LOOP      , 0, CTRL('d'),     0 },
+  { "\"map_view\"",         DEMO_CONTEXT, change_mode_func,       (void *)AUTOMAP_LOOP   , 0, CTRL('a'),     0 },
+  { "\"clear_fullscreen\"", DEMO_CONTEXT, clear_fullscreen_func,  NULL                   , 0, DOWN(KEY_BS),  0 },
+  { "\"save_game\"",        DEMO_CONTEXT, save_hotkey_func,       NULL                   , 0, CTRL('s'),     0 },
+  { "\"load_game\"",        DEMO_CONTEXT, saveload_hotkey_func,   (void *)TRUE           , 0, CTRL('l'),     0 },
+  { "\"pause\"",            DEMO_CONTEXT, pause_game_func,        (void *)TRUE           , 0, DOWN('p'),     0 },
+  { "\"reload_weapon 1\"",  DEMO_CONTEXT, reload_weapon_hotkey,   (void *)1              , 0, CTRL(KEY_BS),  0 },
+  { "\"reload_weapon 0\"",  DEMO_CONTEXT, reload_weapon_hotkey,   (void *)0              , 0, ALT(KEY_BS),   0 },
+  { "\"select_grenade\"",   DEMO_CONTEXT, select_grenade_hotkey,  (void *)0              , 0, CTRL('\''),    0 },
+  { "\"toggle_olh\"",       DEMO_CONTEXT, toggle_olh_func,        NULL                   , 0, CTRL('h'),     0 },
+  { "\"select_drug\"",      DEMO_CONTEXT, select_drug_hotkey,     (void *)0              , 0, CTRL(';'),     0 },
+  { "\"toggle_music\"",     DEMO_CONTEXT, toggle_music_func,      NULL                   , 0, CTRL('m'),     0 },
+  { "\"quit\"",             DEMO_CONTEXT, MacQuitFunc,            NULL                   , 0, CTRL('q'),     0 },
+  { "\"cycle_weapons 1\"",  DEMO_CONTEXT, cycle_weapons_func,     (void *)1              , 0, TAB_KEY,       0 },
+  { "\"cycle_weapons -1\"", DEMO_CONTEXT, cycle_weapons_func,     (void *)-1             , 0, S_TAB_KEY,     0 },
+  { "\"cycle_detail\"",     DEMO_CONTEXT, MacDetailFunc,          NULL                   , 0, CTRL('1'),     0 },
+  { "\"toggle_opengl\"",   EVERY_CONTEXT, toggle_opengl_func,     NULL                   , 0, CTRL('g'),     0 },
+  { "\"arm_grenade\"",      DEMO_CONTEXT, arm_grenade_hotkey,     (void *)0              , 0, ALT('\''),     0 },
+  { "\"use_drug\"",         DEMO_CONTEXT, use_drug_hotkey,        (void *)0              , 0, ALT(';'),      0 },
+  { "\"hud_color\"",        DEMO_CONTEXT, hud_color_bank_cycle,   NULL                   , 0, ALT('h'),      0 },
+  { "\"showhelp\"",         DEMO_CONTEXT, olh_overlay_func,       &olh_overlay_on        , 0, ALT('o'),      0 },
+  { "\"keypad 0\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('0'),     0 },
+  { "\"keypad 1\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('1'),     0 },
+  { "\"keypad 2\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('2'),     0 },
+  { "\"keypad 3\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('3'),     0 },
+  { "\"keypad 4\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('4'),     0 },
+  { "\"keypad 5\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('5'),     0 },
+  { "\"keypad 6\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('6'),     0 },
+  { "\"keypad 7\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('7'),     0 },
+  { "\"keypad 8\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('8'),     0 },
+  { "\"keypad 9\"",         DEMO_CONTEXT, keypad_hotkey_func,     NULL                   , 0, DOWN('9'),     0 },
+  { "\"mac_help\"",         DEMO_CONTEXT, MacHelpFunc,            NULL                   , 0, CTRL('/'),     0 },
+  { "\"toggle_options\"",   DEMO_CONTEXT, wrapper_options_func,   (void *)TRUE           , 0, DOWN(KEY_ESC), 0 },
+  { "\"cheat_give_all\"",   DEMO_CONTEXT, toggle_giveall_func,    (void *)TRUE           , 0, CTRL('2'),     0 },
+  { "\"cheat_physics\"",    DEMO_CONTEXT, toggle_physics_func,    (void *)TRUE           , 0, CTRL('3'),     0 },
+  { "\"cheat_up_level\"",   DEMO_CONTEXT, toggle_up_level_func,   (void *)TRUE           , 0, CTRL('4'),     0 },
+  { "\"cheat_down_level\"", DEMO_CONTEXT, toggle_down_level_func, (void *)TRUE           , 0, CTRL('5'),     0 },
+
+  { NULL, 0, 0, 0 }
+};
+
+
+
+//ought to be enough for anybody
+#define MAX_FIRE_KEYS  16
+
+int FireKeys[MAX_FIRE_KEYS+1]; //see input.c
+
+
+
+//all hotkey initialization and hotkey_add()s are done in this function
+//also handles setting fire keybinds
+void LoadHotkeyKeybinds(void)
+{
+  FILE *f;
+  char temp[512], *p;
+  const char *string;
+  int len, i, flags, ch, fire_key_index = 0;
+
+  hotkey_init(NUM_HOTKEYS);
+
+  //clear hotkey used flags so we can tell which weren't specified in file
+  //later we can add default key chars for them
+  i = 0;
+  while (HotKeyLookup[i].s != NULL)
+  {
+    HotKeyLookup[i].used = FALSE;
+    i++;
+  }
+
+  //get path and filename of keybinds file
+  p = SDL_GetPrefPath("Interrupt", "SystemShock");
+  snprintf(temp, sizeof(temp), "%s%s", p, KEYBINDS_FILENAME);
+  free(p);
+
+  f = fopen(temp, "r");
+  if (f)
+  {
+    //scan keybinds file line by line
+    while (fgets(temp, sizeof(temp), f))
+    {
+      LowerCaseInPlace(temp);
+      p = temp;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      string = "bind"; len = strlen(string);
+      if (strncmp(p, string, len)) continue;
+      p += len;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      flags = KB_FLAG_DOWN;
+      ch = 0;
+
+      string = "shift+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_SHIFT;}
+
+      string = "ctrl+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_CTRL;}
+
+      string = "alt+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_ALT;}
+
+      //get ascii char from key name
+      i = 0;
+      while (KeyName2ChCode[i].s != NULL)
+      {
+        string = KeyName2ChCode[i].s; len = strlen(string);
+        if (!strncmp(p, string, len)) {p += len; ch = KeyName2ChCode[i].ch | flags; break;}
+        i++;
+      }
+      if (ch == 0) continue;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      //lookup and add specified hotkey info
+      i = 0;
+      while (HotKeyLookup[i].s != NULL)
+      {
+        string = HotKeyLookup[i].s; len = strlen(string);
+        if (!strncmp(p, string, len))
+        {
+          hotkey_add(ch, HotKeyLookup[i].contexts, HotKeyLookup[i].func, HotKeyLookup[i].state);
+          HotKeyLookup[i].used = TRUE;
+          break;
+        }
+        i++;
+      }
+
+      //special case for fire keys
+      string = "\"fire\""; len = strlen(string);
+      if (!strncmp(p, string, len))
+      {
+        if (fire_key_index < MAX_FIRE_KEYS)
+          FireKeys[fire_key_index++] = (ch & ~KB_FLAG_DOWN);
+      }
+    }
+
+    fclose(f);
+  }
+
+  //add defaults for unused hotkeys
+  i = 0;
+  while (HotKeyLookup[i].s != NULL)
+  {
+    if (!HotKeyLookup[i].used)
+    {
+      //add default 1
+      ch = HotKeyLookup[i].def1;
+      if (ch) hotkey_add(ch, HotKeyLookup[i].contexts, HotKeyLookup[i].func, HotKeyLookup[i].state);
+
+      //add default 2
+      ch = HotKeyLookup[i].def2;
+      if (ch) hotkey_add(ch, HotKeyLookup[i].contexts, HotKeyLookup[i].func, HotKeyLookup[i].state);
+    }
+    i++;
+  }
+
+  //add default fire key if none were specified
+  if (fire_key_index == 0)
+    FireKeys[fire_key_index++] = KEY_ENTER;
+
+  //signal end of fire key list
+  FireKeys[fire_key_index] = 0;
+}
+
+
+
+//************************************************************************************
+
+
+
+//**********************************
+//Set move keybinds (see movekeys.c)
+//**********************************
+
+
+
+extern MOVE_KEYBIND      MoveKeybinds[MAX_MOVE_KEYBINDS+1];
+extern MOVE_KEYBIND MoveCyberKeybinds[MAX_MOVE_KEYBINDS+1];
+
+
+
+#define CODE_Q         0x0C
+#define CODE_W         0x0D
+#define CODE_E         0x0E
+#define CODE_A         0x00
+#define CODE_S         0x01
+#define CODE_D         0x02
+#define CODE_Z         0x06
+#define CODE_X         0x07
+#define CODE_C         0x08
+#define CODE_R         0x0F
+#define CODE_V         0x09
+#define CODE_J         0x26
+#define CODE_SPACE     0x31
+#define CODE_UP        0x7E
+#define CODE_LEFT      0x7B
+#define CODE_RIGHT     0x7C
+#define CODE_DOWN      0x7D
+#define CODE_KP_HOME   0x59
+#define CODE_KP_UP     0x5B
+#define CODE_KP_PGUP   0x5C
+#define CODE_KP_LEFT   0x56
+#define CODE_KP_5      0x57
+#define CODE_KP_RIGHT  0x58
+#define CODE_KP_END    0x53
+#define CODE_KP_DOWN   0x54
+#define CODE_KP_PGDN   0x55
+
+
+
+static MOVE_KEYBIND MoveKeybindsDefault[] =
+{
+  { CODE_W        | KB_FLAG_SHIFT, M_RUNFORWARD    },
+  { CODE_UP       | KB_FLAG_SHIFT, M_RUNFORWARD    },
+  { CODE_UP       | KB_FLAG_ALT  , M_RUNFORWARD    },
+  { CODE_KP_UP    | KB_FLAG_SHIFT, M_RUNFORWARD    },
+  { CODE_KP_UP    | KB_FLAG_ALT  , M_RUNFORWARD    },
+  { CODE_W                       , M_FORWARD       },
+  { CODE_UP                      , M_FORWARD       },
+  { CODE_KP_UP                   , M_FORWARD       },
+  { CODE_Z        | KB_FLAG_SHIFT, M_FASTTURNLEFT  },
+  { CODE_LEFT     | KB_FLAG_SHIFT, M_FASTTURNLEFT  },
+  { CODE_KP_LEFT  | KB_FLAG_SHIFT, M_FASTTURNLEFT  },
+  { CODE_Z                       , M_TURNLEFT      },
+  { CODE_LEFT                    , M_TURNLEFT      },
+  { CODE_KP_LEFT                 , M_TURNLEFT      },
+  { CODE_C        | KB_FLAG_SHIFT, M_FASTTURNRIGHT },
+  { CODE_RIGHT    | KB_FLAG_SHIFT, M_FASTTURNRIGHT },
+  { CODE_KP_RIGHT | KB_FLAG_SHIFT, M_FASTTURNRIGHT },
+  { CODE_C                       , M_TURNRIGHT     },
+  { CODE_RIGHT                   , M_TURNRIGHT     },
+  { CODE_KP_RIGHT                , M_TURNRIGHT     },
+  { CODE_S                       , M_BACK          },
+  { CODE_S        | KB_FLAG_SHIFT, M_BACK          },
+  { CODE_DOWN                    , M_BACK          },
+  { CODE_DOWN     | KB_FLAG_SHIFT, M_BACK          },
+  { CODE_DOWN     | KB_FLAG_ALT  , M_BACK          },
+  { CODE_KP_DOWN                 , M_BACK          },
+  { CODE_KP_DOWN  | KB_FLAG_SHIFT, M_BACK          },
+  { CODE_KP_DOWN  | KB_FLAG_ALT  , M_BACK          },
+  { CODE_A                       , M_SLIDELEFT     },
+  { CODE_A        | KB_FLAG_SHIFT, M_SLIDELEFT     },
+  { CODE_LEFT     | KB_FLAG_ALT  , M_SLIDELEFT     },
+  { CODE_KP_LEFT  | KB_FLAG_ALT  , M_SLIDELEFT     },
+  { CODE_KP_END                  , M_SLIDELEFT     },
+  { CODE_D                       , M_SLIDERIGHT    },
+  { CODE_D        | KB_FLAG_SHIFT, M_SLIDERIGHT    },
+  { CODE_RIGHT    | KB_FLAG_ALT  , M_SLIDERIGHT    },
+  { CODE_KP_RIGHT | KB_FLAG_ALT  , M_SLIDERIGHT    },
+  { CODE_KP_PGDN                 , M_SLIDERIGHT    },
+  { CODE_J                       , M_JUMP          },
+  { CODE_J        | KB_FLAG_SHIFT, M_JUMP          },
+  { CODE_SPACE                   , M_JUMP          },
+  { CODE_SPACE    | KB_FLAG_SHIFT, M_JUMP          },
+  { CODE_SPACE    | KB_FLAG_CTRL , M_JUMP          },
+  { CODE_SPACE    | KB_FLAG_ALT  , M_JUMP          },
+  { CODE_X                       , M_LEANUP        },
+  { CODE_X        | KB_FLAG_SHIFT, M_LEANUP        },
+  { CODE_X        | KB_FLAG_CTRL , M_LEANUP        },
+  { CODE_X        | KB_FLAG_ALT  , M_LEANUP        },
+  { CODE_Q                       , M_LEANLEFT      },
+  { CODE_Q        | KB_FLAG_SHIFT, M_LEANLEFT      },
+  { CODE_LEFT     | KB_FLAG_CTRL , M_LEANLEFT      },
+  { CODE_KP_LEFT  | KB_FLAG_CTRL , M_LEANLEFT      },
+  { CODE_E                       , M_LEANRIGHT     },
+  { CODE_E        | KB_FLAG_SHIFT, M_LEANRIGHT     },
+  { CODE_RIGHT    | KB_FLAG_CTRL , M_LEANRIGHT     },
+  { CODE_KP_RIGHT | KB_FLAG_CTRL , M_LEANRIGHT     },
+  { CODE_R                       , M_LOOKUP        },
+  { CODE_R        | KB_FLAG_SHIFT, M_LOOKUP        },
+  { CODE_R        | KB_FLAG_CTRL , M_LOOKUP        },
+  { CODE_UP       | KB_FLAG_CTRL , M_LOOKUP        },
+  { CODE_KP_UP    | KB_FLAG_CTRL , M_LOOKUP        },
+  { CODE_V                       , M_LOOKDOWN      },
+  { CODE_V        | KB_FLAG_SHIFT, M_LOOKDOWN      },
+  { CODE_V        | KB_FLAG_CTRL , M_LOOKDOWN      },
+  { CODE_DOWN     | KB_FLAG_CTRL , M_LOOKDOWN      },
+  { CODE_KP_DOWN  | KB_FLAG_CTRL , M_LOOKDOWN      },
+  { CODE_KP_HOME                 , M_RUNLEFT       },
+  { CODE_KP_PGUP                 , M_RUNRIGHT      },
+  { CODE_S                       , M_THRUST        }, //cyber start
+  { CODE_S        | KB_FLAG_SHIFT, M_THRUST        },
+  { CODE_KP_5                    , M_THRUST        },
+  { CODE_W                       , M_CLIMB         },
+  { CODE_W        | KB_FLAG_SHIFT, M_CLIMB         },
+  { CODE_UP                      , M_CLIMB         },
+  { CODE_UP       | KB_FLAG_SHIFT, M_CLIMB         },
+  { CODE_UP       | KB_FLAG_CTRL , M_CLIMB         },
+  { CODE_UP       | KB_FLAG_ALT  , M_CLIMB         },
+  { CODE_KP_UP                   , M_CLIMB         },
+  { CODE_KP_UP    | KB_FLAG_SHIFT, M_CLIMB         },
+  { CODE_KP_UP    | KB_FLAG_CTRL , M_CLIMB         },
+  { CODE_KP_UP    | KB_FLAG_ALT  , M_CLIMB         },
+  { CODE_A                       , M_BANKLEFT      },
+  { CODE_A        | KB_FLAG_SHIFT, M_BANKLEFT      },
+  { CODE_KP_LEFT                 , M_BANKLEFT      },
+  { CODE_KP_LEFT  | KB_FLAG_SHIFT, M_BANKLEFT      },
+  { CODE_KP_LEFT  | KB_FLAG_CTRL , M_BANKLEFT      },
+  { CODE_KP_LEFT  | KB_FLAG_ALT  , M_BANKLEFT      },
+  { CODE_D                       , M_BANKRIGHT     },
+  { CODE_D        | KB_FLAG_SHIFT, M_BANKRIGHT     },
+  { CODE_KP_RIGHT                , M_BANKRIGHT     },
+  { CODE_KP_RIGHT | KB_FLAG_SHIFT, M_BANKRIGHT     },
+  { CODE_KP_RIGHT | KB_FLAG_CTRL , M_BANKRIGHT     },
+  { CODE_KP_RIGHT | KB_FLAG_ALT  , M_BANKRIGHT     },
+  { CODE_X                       , M_DIVE          },
+  { CODE_X        | KB_FLAG_SHIFT, M_DIVE          },
+  { CODE_DOWN                    , M_DIVE          },
+  { CODE_DOWN     | KB_FLAG_SHIFT, M_DIVE          },
+  { CODE_DOWN     | KB_FLAG_CTRL , M_DIVE          },
+  { CODE_DOWN     | KB_FLAG_ALT  , M_DIVE          },
+  { CODE_KP_DOWN                 , M_DIVE          },
+  { CODE_KP_DOWN  | KB_FLAG_SHIFT, M_DIVE          },
+  { CODE_KP_DOWN  | KB_FLAG_CTRL , M_DIVE          },
+  { CODE_KP_DOWN  | KB_FLAG_ALT  , M_DIVE          },
+  { CODE_Q                       , M_ROLLRIGHT     },
+  { CODE_Q        | KB_FLAG_SHIFT, M_ROLLRIGHT     },
+  { CODE_Z                       , M_ROLLRIGHT     },
+  { CODE_Z        | KB_FLAG_SHIFT, M_ROLLRIGHT     },
+  { CODE_E                       , M_ROLLLEFT      },
+  { CODE_E        | KB_FLAG_SHIFT, M_ROLLLEFT      },
+  { CODE_C                       , M_ROLLLEFT      },
+  { CODE_C        | KB_FLAG_SHIFT, M_ROLLLEFT      },
+  { CODE_KP_HOME                 , M_CLIMBLEFT     },
+  { CODE_KP_HOME  | KB_FLAG_SHIFT, M_CLIMBLEFT     },
+  { CODE_KP_HOME  | KB_FLAG_CTRL , M_CLIMBLEFT     },
+  { CODE_KP_HOME  | KB_FLAG_ALT  , M_CLIMBLEFT     },
+  { CODE_KP_PGUP                 , M_CLIMBRIGHT    },
+  { CODE_KP_PGUP  | KB_FLAG_SHIFT, M_CLIMBRIGHT    },
+  { CODE_KP_PGUP  | KB_FLAG_CTRL , M_CLIMBRIGHT    },
+  { CODE_KP_PGUP  | KB_FLAG_ALT  , M_CLIMBRIGHT    },
+  { CODE_KP_PGDN                 , M_DIVERIGHT     },
+  { CODE_KP_PGDN  | KB_FLAG_SHIFT, M_DIVERIGHT     },
+  { CODE_KP_PGDN  | KB_FLAG_CTRL , M_DIVERIGHT     },
+  { CODE_KP_PGDN  | KB_FLAG_ALT  , M_DIVERIGHT     },
+  { CODE_KP_END                  , M_DIVELEFT      },
+  { CODE_KP_END   | KB_FLAG_SHIFT, M_DIVELEFT      },
+  { CODE_KP_END   | KB_FLAG_CTRL , M_DIVELEFT      },
+  { CODE_KP_END   | KB_FLAG_ALT  , M_DIVELEFT      },
+
+  { 255                          , -1              }
+};
+
+
+
+static struct {const char *s; int move;} MoveName2Move[] =
+{
+  { "\"runforward\"",    M_RUNFORWARD    },
+  { "\"forward\"",       M_FORWARD       },
+  { "\"fastturnleft\"",  M_FASTTURNLEFT  },
+  { "\"turnleft\"",      M_TURNLEFT      },
+  { "\"fastturnright\"", M_FASTTURNRIGHT },
+  { "\"turnright\"",     M_TURNRIGHT     },
+  { "\"back\"",          M_BACK          },
+  { "\"slideleft\"",     M_SLIDELEFT     },
+  { "\"slideright\"",    M_SLIDERIGHT    },
+  { "\"jump\"",          M_JUMP          },
+  { "\"leanup\"",        M_LEANUP        },
+  { "\"leanleft\"",      M_LEANLEFT      },
+  { "\"leanright\"",     M_LEANRIGHT     },
+  { "\"lookup\"",        M_LOOKUP        },
+  { "\"lookdown\"",      M_LOOKDOWN      },
+  { "\"runleft\"",       M_RUNLEFT       },
+  { "\"runright\"",      M_RUNRIGHT      },
+  { "\"thrust\"",        M_THRUST        }, //cyber start
+  { "\"climb\"",         M_CLIMB         },
+  { "\"bankleft\"",      M_BANKLEFT      },
+  { "\"bankright\"",     M_BANKRIGHT     },
+  { "\"dive\"",          M_DIVE          },
+  { "\"rollright\"",     M_ROLLRIGHT     },
+  { "\"rollleft\"",      M_ROLLLEFT      },
+  { "\"climbleft\"",     M_CLIMBLEFT     },
+  { "\"climbright\"",    M_CLIMBRIGHT    },
+  { "\"diveright\"",     M_DIVERIGHT     },
+  { "\"diveleft\"",      M_DIVELEFT      },
+
+  { NULL,                0               }
+};
+
+
+
+void LoadMoveKeybinds(void)
+{
+  FILE *f;
+  char temp[512], *p, move_used[NUM_MOVES];
+  const char *string;
+  int len, i, flags, code, move, num_bound = 0, num_cyber_bound = 0;
+
+  //keep track of which moves are specified so we can add default ones for those that are missing
+  memset(move_used, 0, NUM_MOVES);
+
+  //get path and filename of keybinds file
+  p = SDL_GetPrefPath("Interrupt", "SystemShock");
+  snprintf(temp, sizeof(temp), "%s%s", p, KEYBINDS_FILENAME);
+  free(p);
+
+  f = fopen(temp, "r");
+  if (f)
+  {
+    //scan keybinds file line by line
+    while (fgets(temp, sizeof(temp), f))
+    {
+      LowerCaseInPlace(temp);
+      p = temp;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      string = "bind"; len = strlen(string);
+      if (strncmp(p, string, len)) continue;
+      p += len;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      flags = 0;
+      code = 255;
+
+      string = "shift+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_SHIFT;}
+
+      string = "ctrl+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_CTRL;}
+
+      string = "alt+"; len = strlen(string);
+      if (!strncmp(p, string, len)) {p += len; flags |= KB_FLAG_ALT;}
+
+      //get code from key name
+      i = 0;
+      while (KeyName2ChCode[i].s != NULL)
+      {
+        string = KeyName2ChCode[i].s; len = strlen(string);
+        if (!strncmp(p, string, len)) {p += len; code = KeyName2ChCode[i].code | flags; break;}
+        i++;
+      }
+      if (code == 255) continue;
+
+      while (*p && isspace(*p)) p++; //skip leading spaces
+
+      //lookup move
+      i = 0;
+      while (MoveName2Move[i].s != NULL)
+      {
+        string = MoveName2Move[i].s; len = strlen(string);
+        if (!strncmp(p, string, len))
+        {
+          move = MoveName2Move[i].move;
+          move_used[move] = 1;
+
+          if (move < M_THRUST) //non-cyber
+          {
+            if (num_bound < MAX_MOVE_KEYBINDS)
+            {
+              //add keybind to list
+              MoveKeybinds[num_bound].code = code;
+              MoveKeybinds[num_bound].move = move;
+              num_bound++;
+            }
+          }
+          else
+          {
+            if (num_cyber_bound < MAX_MOVE_KEYBINDS)
+            {
+              //add cyber keybind to list
+              MoveCyberKeybinds[num_cyber_bound].code = code;
+              MoveCyberKeybinds[num_cyber_bound].move = move;
+              num_cyber_bound++;
+            }
+          }
+
+          break;
+        }
+        i++;
+      }
+    }
+
+    fclose(f);
+  }
+
+  //for moves that weren't referenced in file, bind default codes to them
+  for (move = 0; move < NUM_MOVES; move++) if (!move_used[move])
+  {
+    i = 0;
+    while (MoveKeybindsDefault[i].code != 255)
+    {
+      if (MoveKeybindsDefault[i].move == move)
+      {
+        code = MoveKeybindsDefault[i].code;
+
+        if (move < M_THRUST) //non-cyber
+        {
+          if (num_bound < MAX_MOVE_KEYBINDS)
+          {
+            //add keybind to list
+            MoveKeybinds[num_bound].code = code;
+            MoveKeybinds[num_bound].move = move;
+            num_bound++;
+          }
+        }
+        else
+        {
+          if (num_cyber_bound < MAX_MOVE_KEYBINDS)
+          {
+            //add cyber keybind to list
+            MoveCyberKeybinds[num_cyber_bound].code = code;
+            MoveCyberKeybinds[num_cyber_bound].move = move;
+            num_cyber_bound++;
+          }
+        }
+      }
+      i++;
+    }
+  }
+
+  //signal end of lists
+  MoveKeybinds[num_bound].code = 255;
+  MoveCyberKeybinds[num_cyber_bound].code = 255;
+
+  extern void init_motion_polling(void); //see movekeys.c
+  init_motion_polling();
+}
+
+
+
+//************************************************************************************
+
+
+
+//*******************************
+//Create default keybinds file
+//*******************************
+
+
+
+#define JUSTIFY_COLUMN  30
+
+
+
+//if ch is 0, use code instead
+static bool WriteKeyName(int ch, int code, FILE *f)
+{
+  int i = 0, len = 0;
+
+  while (KeyName2ChCode[i].s != NULL)
+  {
+    if (ch) { if (KeyName2ChCode[i].ch   == (ch   & 255)) break; }
+    else    { if (KeyName2ChCode[i].code == (code & 255)) break; }
+    i++;
+  }
+  if (KeyName2ChCode[i].s == NULL) return 0;
+
+  fputs("bind  ", f); len += 6;
+
+  if ((ch ? ch : code) & KB_FLAG_SHIFT) {fputs("shift+", f); len += 6;}
+  if ((ch ? ch : code) &  KB_FLAG_CTRL) {fputs("ctrl+",  f); len += 5;}
+  if ((ch ? ch : code) &   KB_FLAG_ALT) {fputs("alt+",   f); len += 4;}
+
+  fputs(KeyName2ChCode[i].s, f); len += strlen(KeyName2ChCode[i].s);
+
+  //add spaces to justify following text
+  while (len < JUSTIFY_COLUMN) {fputc(' ', f); len++;}
+
+  return 1;
+}
+
+
+
+static void WriteMoveName(int move, FILE *f)
+{
+  int i;
+
+  //find move name that matches move
+  i = 0;
+  while (MoveName2Move[i].s != NULL)
+  {
+    if (MoveName2Move[i].move == move) break;
+    i++;
+  }
+
+  if (MoveName2Move[i].s != NULL)
+  {
+    fputs(MoveName2Move[i].s, f);
+    fputs("\n", f);
+  }
+}
+
+
+
+//create default keybinds file if it doesn't already exist
+void CreateDefaultKeybindsFile(void)
+{
+  FILE *f;
+  char temp[512], *p;
+  int i, ch;
+
+  //get path and filename of keybinds file
+  p = SDL_GetPrefPath("Interrupt", "SystemShock");
+  snprintf(temp, sizeof(temp), "%s%s", p, KEYBINDS_FILENAME);
+  free(p);
+
+  //check if file already exists; if so, return
+  f = fopen(temp, "r");
+  if (f != NULL) {fclose(f); return;}
+
+  //open new file for writing
+  f = fopen(temp, "w");
+  if (f == NULL) return;
+
+  //write default hotkey keybinds
+  i = 0;
+  while (HotKeyLookup[i].s)
+  {
+    //default 1 if it exists (it should)
+    ch = HotKeyLookup[i].def1;
+    if (ch && WriteKeyName(ch, 0, f))
+    {
+      fputs(HotKeyLookup[i].s, f);
+      fputs("\n", f);
+    }
+
+    //default 2 if it exists (it might not)
+    ch = HotKeyLookup[i].def2;
+    if (ch && WriteKeyName(ch, 0, f))
+    {
+      fputs(HotKeyLookup[i].s, f);
+      fputs("\n", f);
+    }
+
+    i++;
+  }
+
+  //write default fire keybind
+  fputs("\n", f);
+  WriteKeyName(KEY_ENTER, 0, f);
+  fputs("\"fire\"\n\n", f);
+
+  //write default move keybinds
+  i = 0;
+  while (MoveKeybindsDefault[i].code != 255)
+  {
+    if (WriteKeyName(0, MoveKeybindsDefault[i].code, f))
+      WriteMoveName(MoveKeybindsDefault[i].move, f);
+
+    i++;
+  }
+
+  fclose(f);
 }

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -446,7 +446,7 @@ extern uchar select_grenade_hotkey(short keycode, ulong context, void *data);
 extern uchar toggle_olh_func(short keycode, ulong context, void *data);
 extern uchar select_drug_hotkey(short keycode, ulong context, void *data);
 extern uchar toggle_music_func(short keycode, ulong context, void *data);
-extern uchar MacQuitFunc(short keycode, ulong context, void *data);
+extern uchar demo_quit_func(short keycode, ulong context, void *data);
 extern uchar cycle_weapons_func(short keycode, ulong context, void *data);
 extern uchar MacDetailFunc(short keycode, ulong context, void *data);
 extern uchar toggle_opengl_func(short keycode, ulong context, void *data);
@@ -504,7 +504,7 @@ HOTKEYLOOKUP HotKeyLookup[] =
   { "\"toggle_olh\"",       DEMO_CONTEXT, toggle_olh_func,        NULL                   , 0, CTRL('h'),     0 },
   { "\"select_drug\"",      DEMO_CONTEXT, select_drug_hotkey,     (void *)0              , 0, CTRL(';'),     0 },
   { "\"toggle_music\"",     DEMO_CONTEXT, toggle_music_func,      NULL                   , 0, CTRL('m'),     0 },
-  { "\"quit\"",             DEMO_CONTEXT, MacQuitFunc,            NULL                   , 0, CTRL('q'),     0 },
+  { "\"quit\"",             DEMO_CONTEXT, demo_quit_func,         NULL                   , 0, CTRL('q'),     0 },
   { "\"cycle_weapons 1\"",  DEMO_CONTEXT, cycle_weapons_func,     (void *)1              , 0, TAB_KEY,       0 },
   { "\"cycle_weapons -1\"", DEMO_CONTEXT, cycle_weapons_func,     (void *)-1             , 0, S_TAB_KEY,     0 },
   { "\"cycle_detail\"",     DEMO_CONTEXT, MacDetailFunc,          NULL                   , 0, CTRL('1'),     0 },

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -113,6 +113,11 @@ extern void object_data_flush(void);
 extern errtype load_da_palette(void);
 extern void ShockMain(void);
 
+//see Prefs.c
+extern void CreateDefaultKeybindsFile(void);
+extern void LoadHotkeyKeybinds(void);
+extern void LoadMoveKeybinds(void);
+
 void InitSDL();
 void SDLDraw(void);
 errtype CheckFreeSpace(short	checkRefNum);
@@ -140,6 +145,12 @@ int main(int argc, char** argv)
 
 	SetDefaultPrefs();
 	LoadPrefs();
+
+    //see Prefs.c
+    CreateDefaultKeybindsFile(); //only if it doesn't already exist
+    //even if keybinds file still doesn't exist, defaults will be set here
+    LoadHotkeyKeybinds();
+    LoadMoveKeybinds();
 	
 #ifdef TESTING
 	SetupTests();


### PR DESCRIPTION
On run, if it doesn't already exist, a default "keybinds.txt" file will be created next to "prefs.txt" (see Prefs.h).

Keybinds file can be edited to bind keys to hotkey, fire or move actions. Key bindings take effect on next run.

movekeys.c was rewritten and is now much clearer.

If for some reason keybinds file cannot be read, default keys will still be properly set.

Also added/fixed:

Use SDL_TEXTINPUT events for printable char keys
Fix ALT key not working
Fix save hotkey
Quit hotkey was quitting without confirmation (!)
Fix randomly dropped modified keys (aka insidious evil)

Commits done.