### PR TITLE
Fix instances of null ptr deref in showobj()

### DIFF
--- a/src/GameSrc/gameobj.c
+++ b/src/GameSrc/gameobj.c
@@ -1084,14 +1084,14 @@ void show_obj(ObjID cobjid) {
             }
             switch (ID2TRIP(cobjid)) {
             case SUPERSCREEN_TRIPLE:
-                scale = 7 - tpdata->wlog;
+                if (tpdata != NULL) scale = 7 - tpdata->wlog;
                 break;
             case TMAP_TRIPLE:
             case BIGSCREEN_TRIPLE:
-                scale = 6 - tpdata->wlog;
+                if (tpdata != NULL) scale = 6 - tpdata->wlog;
                 break;
             case SCREEN_TRIPLE:
-                scale = 5 - tpdata->wlog;
+                if (tpdata != NULL) scale = 5 - tpdata->wlog;
                 break;
             }
             switch (ID2TRIP(cobjid)) {
@@ -1168,7 +1168,7 @@ void show_obj(ObjID cobjid) {
         corn[1] = g3_copy_add_delta_x(corn[0], fix_xoff << 1);
         corn[2] = g3_copy_add_delta_y(corn[1], fix_yoff << 1);
         corn[3] = g3_copy_add_delta_y(corn[0], fix_yoff << 1);
-        _fr_draw_tmtile(tpdata, tluc_val, corn, (_fr_cobj->obclass == CLASS_DOOR), light_me);
+        if (tpdata != NULL) _fr_draw_tmtile(tpdata, tluc_val, corn, (_fr_cobj->obclass == CLASS_DOOR), light_me);
         if (use_cache)
             release_obj_cache_bitmap(ref);
         g3_end_object();


### PR DESCRIPTION
If animated screens on walls don't load for whatever reason, showobj() still tries to draw them with a null ptr, causing a crash. 9 out of 10 players agree, no screen is better than crash.