### PR TITLE
Fix animated screen not loaded crash

### DIFF
--- a/src/GameSrc/gameobj.c
+++ b/src/GameSrc/gameobj.c
@@ -546,9 +546,9 @@ void _fr_draw_tmtile(grs_bitmap *draw_bm, int col_val, g3s_phandle *plst, uchar 
         fpoly_rend(col_val, 4, plst);
         gr_set_fill_type(cur_ft);
     } else if (use_opengl()) {
-        opengl_light_tmap(4, plst, draw_bm);
+        if (draw_bm != NULL) opengl_light_tmap(4, plst, draw_bm);
     } else {
-        g3_light_tmap(4, plst, draw_bm);
+        if (draw_bm != NULL) g3_light_tmap(4, plst, draw_bm);
     }
     if (dblface) // draw the bleeding backside, nudge nudge
     {
@@ -572,9 +572,9 @@ void _fr_draw_tmtile(grs_bitmap *draw_bm, int col_val, g3s_phandle *plst, uchar 
                 fpoly_rend(col_val, 4, plst);
                 gr_set_fill_type(cur_ft);
             } else if (use_opengl()) {
-                opengl_light_tmap(4, plst, draw_bm);
+                if (draw_bm != NULL) opengl_light_tmap(4, plst, draw_bm);
             } else {
-                g3_light_tmap(4, plst, draw_bm);
+                if (draw_bm != NULL) g3_light_tmap(4, plst, draw_bm);
             }
         }
     }
@@ -1168,7 +1168,7 @@ void show_obj(ObjID cobjid) {
         corn[1] = g3_copy_add_delta_x(corn[0], fix_xoff << 1);
         corn[2] = g3_copy_add_delta_y(corn[1], fix_yoff << 1);
         corn[3] = g3_copy_add_delta_y(corn[0], fix_yoff << 1);
-        if (tpdata != NULL) _fr_draw_tmtile(tpdata, tluc_val, corn, (_fr_cobj->obclass == CLASS_DOOR), light_me);
+        _fr_draw_tmtile(tpdata, tluc_val, corn, (_fr_cobj->obclass == CLASS_DOOR), light_me);
         if (use_cache)
             release_obj_cache_bitmap(ref);
         g3_end_object();


### PR DESCRIPTION
Crash setup:
Load a save game just before entering cyberspace to fight shodan.
Win or lose game and return to menu.
Load save game in west elevator on level 2.
Walk into the hallway near the animated screens in the room full of bodies.
As soon as the game tries to render the screens the game crashes.

What happens is that in show_obj() the animated screen texture tries to load but fails (there is a message in the console). I can't find the cause, but in the meantime prevent the crash by checking for a null bitmap. The screens on the walls won't appear, though.

Exiting the program, then loading the save and walking near the screens fixes the problem. It might be related to some quirk of how resources are handled.

Edit: The screens seem to load now, or I haven't been able to reproduce the issue anymore.

Edit2: The null checks can't hurt, anyway.