### PR TITLE
Empty slate after return to setup or when loading game

### DIFF
--- a/src/GameSrc/gamewrap.c
+++ b/src/GameSrc/gamewrap.c
@@ -344,6 +344,10 @@ errtype load_game(char *fname) {
 
     INFO("load_game %s", fname);
 
+    //see setup.c
+    extern void empty_slate(void);
+    empty_slate();
+
     closedown_game(TRUE);
     // KLC - don't do this here   stop_music();
 

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -1535,8 +1535,16 @@ void empty_slate(void)
   extern uchar *shodan_bitmask;
   shodan_bitmask = NULL;
 
-  extern void reset_input_system(void);
-  reset_input_system();
+  extern uchar alternate_death;
+  alternate_death = FALSE;
+
+  extern uiSlab fullscreen_slab;
+  extern uiSlab main_slab;
+  uiPopSlabCursor(&fullscreen_slab);
+  uiPopSlabCursor(&main_slab);
+
+  extern uchar fire_slam;
+  fire_slam = FALSE;
 
   extern short inventory_page;
   inventory_page = 0;

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -1532,6 +1532,9 @@ void empty_slate(void)
   extern uint _fr_glob_flags;
   _fr_glob_flags = 0;
 
+  extern uchar *shodan_bitmask;
+  shodan_bitmask = NULL;
+
   extern void reset_input_system(void);
   reset_input_system();
 
@@ -1640,10 +1643,6 @@ void setup_start(void)
   }
 
   if (music_on) MacTuneLoadTheme("titloop", 0);
-
-  //need to reset this; it is essentially the endgame flag
-  extern uchar *shodan_bitmask;
-  shodan_bitmask = NULL;
 
   CaptureMouse(false);
 }

--- a/src/GameSrc/setup.c
+++ b/src/GameSrc/setup.c
@@ -555,9 +555,7 @@ void WaitForKey(ulong ticks, int ch)
 
       if (track >= 0 && track < NumTracks)
       {
-        int volume = 127;
-        //int volume = long_sqrt(127 * QUESTVAR_GET(MUSIC_VOLUME_QVAR)); //0-127
-
+        int volume = (int)curr_vol_lev * 127 / 100; //convert from 0-100 to 0-127
         StartTrack(i, track, volume);
 
         if (!WonGame_ShowStats) CreditsTune = (CreditsTune + 1) % 8;
@@ -1500,9 +1498,7 @@ void setup_loop(void)
     int track = 0;
     if (track >= 0 && track < NumTracks)
     {
-      int volume = 127;
-      //int volume = long_sqrt(127 * QUESTVAR_GET(MUSIC_VOLUME_QVAR)); //0-127
-
+      int volume = (int)curr_vol_lev * 127 / 100; //convert from 0-100 to 0-127
       StartTrack(i, track, volume);
     }
   }
@@ -1527,11 +1523,41 @@ void setup_loop(void)
   }
 }
 
+//if these don't get reset, sticky residue of any old game sticks around
+void empty_slate(void)
+{
+  extern int flush_resource_cache(void);
+  flush_resource_cache();
 
+  extern uint _fr_glob_flags;
+  _fr_glob_flags = 0;
+
+  extern void reset_input_system(void);
+  reset_input_system();
+
+  extern short inventory_page;
+  inventory_page = 0;
+
+  extern short inv_last_page;
+  inv_last_page = -1;
+
+  extern void physics_zero_all_controls(void);
+  physics_zero_all_controls();
+
+  extern int mlook_enabled;
+  mlook_enabled = 0;
+}
 
 void setup_start(void)
 {
   int do_i_svg = -1, i_invuln = 0;
+
+  empty_slate();
+
+  player_struct.name[0] = 0;
+
+  for (int i = 0; i < 4; i++)
+    player_struct.difficulty[i] = 2;
 
   MacTuneKillCurrentTheme();
 


### PR DESCRIPTION
Fixes all kinds of problems when starting a new or loading a saved game.

Also pass along current volume of title and credits music to start_track(), even though it doesn't currently use it; left out of old PR.