### PR TITLE
Reset weapon button up + Fix win Esc skips credits

### DIFF
--- a/src/GameSrc/damage.c
+++ b/src/GameSrc/damage.c
@@ -497,6 +497,9 @@ void player_dies() {
     reset_input_system();
     chg_set_sta(GL_CHG_2); // disable the input system
 
+    extern uchar weapon_button_up;
+    weapon_button_up = TRUE;
+
     // clear off hud & prep for funky regen FX
     //   hud_unset(HUD_ALL);
     physics_zero_all_controls();


### PR DESCRIPTION
If weapon_button_up doesn't get reset (TRUE), first press of weapon button will be ignored. This is noticeable when exiting a regeneration chamber, but also belongs in empty_slate().

Also, unrelated to above, prevent skipping credits when pressing Esc at win statistics screen by waiting a few seconds before acknowledging Esc in credits.