### PR TITLE
Implement shift+leftclick for fast object pickup

### DIFF
--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -567,10 +567,12 @@ void pump_events(void)
 
         if (mouseEvent.type != 0)
         {
+          bool shifted = ((SDL_GetModState() & KMOD_SHIFT) != 0);
+
           mouseEvent.x = MouseX;
           mouseEvent.y = MouseY;
           mouseEvent.timestamp = mouse_get_time();
-          mouseEvent.modifiers = 0;
+          mouseEvent.modifiers = (shifted ? 1 : 0);
           addMouseEvent(&mouseEvent);
         }
       }


### PR DESCRIPTION
Shift+leftclicking a container/body once shows contents, leaving mouselook alone. Second time puts important object on cursor then in inventory if possible, also leaving mouselook alone.

Shift+leftclicking an object like a patch or weapon puts it on cursor then in inventory if possible, leaving mouselook alone. Any weapon added this way (to an empty slot) is selected.

Shift+leftclicking something like a keypad turns mouselook off.