### PR TITLE
Handle gamma pref in SetSDLPalette()

### DIFF
--- a/src/GameSrc/tools.c
+++ b/src/GameSrc/tools.c
@@ -863,14 +863,7 @@ void string_replace_char(char *s, char from, char to) {
     };
 }
 
+//gamma param not used here; see SetSDLPalette() in Shock.c
 void gamma_dealfunc(ushort gamma_qvar) {
-    fix gamma;
-
-    if (gamma_qvar > 99)
-        gamma_qvar = 99;
-    gamma_qvar = (ushort)(((int)gamma_qvar * FIX_UNIT) / 100);
-    gamma = FIX_UNIT - fix_make(0, gamma_qvar);
-    gamma = fix_mul(gamma, gamma) + (FIX_UNIT / 2);
-    //	gamma=QVAR_TO_GAMMA(gamma_qvar);
-    gr_set_gamma_pal(0, 256, gamma);
+    gr_set_gamma_pal(0, 256, 0);
 }

--- a/src/Libraries/2D/Source/pal.c
+++ b/src/Libraries/2D/Source/pal.c
@@ -61,21 +61,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "pal.h"
 #include "lg.h"
 
-/* this needs to go into the fix library */
-
-
-static uchar tmp_pal [3*256];  /* bogus -- need to use the tmp buffer */
-
+//gamma param not used here; see SetSDLPalette() in Shock.c
 void gr_set_gamma_pal (int start, int n, fix gamma)
 {
-  int i;
- 
-  /* set gamma corrected values from grd_pal into tmp buf */
-  for (i=start*3;i<3*(start+n);++i) 
-    tmp_pal[i] = (uchar)fix_rint(fix_pow(fix_make(grd_pal[i],0)/255,gamma)*255);
-
-  /* write tmp buf into hardware */
-  gr_set_screen_pal (0, 256, tmp_pal);
+  gr_set_screen_pal (start, n, grd_pal+3*start);
 }
 
 /* copy user's palette into shadow palette, then set real palette. */

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -189,8 +189,9 @@ OSErr LoadPrefs(void) {
             gShockPrefs.goOnScreenHelp = is_true(value);
         } else if (strcasecmp(key, PREF_GAMMA) == 0) {
             int gamma = atoi(value);
-            if (gamma >= 0 && gamma <= 100)
-                gShockPrefs.doGamma = gamma;
+            if (gamma < 10) gamma = 10;
+            if (gamma > 100) gamma = 100;
+            gShockPrefs.doGamma = gamma;
         }
     }
 

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -299,28 +299,49 @@ SDL_Color gamePalette[256];
 bool UseCutscenePalette = FALSE; //see cutsloop.c
 void SetSDLPalette(int index, int count, uchar *pal)
 {
-	for(int i = index; i < index+count; i++) {
-		gamePalette[i].r = *pal++;
-		gamePalette[i].g = *pal++;
-		gamePalette[i].b = *pal++;
-		gamePalette[i].a = 0xFF;
-	}
+  double gamma = (double)gShockPrefs.doGamma;
 
-    if (!UseCutscenePalette)
-    {
-        // Hack black!
-        gamePalette[255].r = 0x0;
-        gamePalette[255].g = 0x0;
-        gamePalette[255].b = 0x0;
-        gamePalette[255].a = 0xff;
-    }
+  if (gamma <  10) gamma = 10;
+  if (gamma > 100) gamma = 100;
 
-	SDL_SetPaletteColors(sdlPalette, gamePalette, 0, 256);
-	SDL_SetSurfacePalette(drawSurface, sdlPalette);
-	SDL_SetSurfacePalette(offscreenDrawSurface, sdlPalette);
+  gamma = gamma * 1.0 / 100;
 
-	if(should_opengl_swap())
-		opengl_change_palette();
+  gamma = 1 - gamma;
+  gamma *= gamma;
+  gamma = 1 - gamma;
+  gamma = 1 / gamma;
+
+  for (int i = index; i < index+count; i++)
+  {
+    double r = (double)(*pal++) / 255;
+    double g = (double)(*pal++) / 255;
+    double b = (double)(*pal++) / 255;
+
+    r = pow(r, gamma);
+    g = pow(g, gamma);
+    b = pow(b, gamma);
+
+    gamePalette[i].r = (int)(r * 255);
+    gamePalette[i].g = (int)(g * 255);
+    gamePalette[i].b = (int)(b * 255);
+    gamePalette[i].a = 0xFF;
+  }
+
+  if (!UseCutscenePalette)
+  {
+    // Hack black!
+    gamePalette[255].r = 0x0;
+    gamePalette[255].g = 0x0;
+    gamePalette[255].b = 0x0;
+    gamePalette[255].a = 0xff;
+  }
+
+  SDL_SetPaletteColors(sdlPalette, gamePalette, 0, 256);
+  SDL_SetSurfacePalette(drawSurface, sdlPalette);
+  SDL_SetSurfacePalette(offscreenDrawSurface, sdlPalette);
+
+  if (should_opengl_swap())
+    opengl_change_palette();
 }
 
 void SDLDraw()


### PR DESCRIPTION
This fixes an old problem I've been having with a too-bright screen that can't be corrected with the gamma slider.

Let me explain:

Before my last graphics driver update, the brightness was correct in windowed mode, but far too bright when switching to fullscreen. The colors also seemed to be washed out.

On the latest graphics driver, the brightness is now always too high, windowed or fullscreen. Only disabling OpenGL (stopping SDL from actually using the OpenGL driver) gets it back to what I expect it should be.

The changes in this PR fix the problem for me, as well as enforce the gamma preference for all palette changes in the game.

Edit:
Using look up table so no math is done for each palette change.