### PR TITLE
Fix end of vmail music/pointer freeze

### DIFF
--- a/src/GameSrc/vmail.c
+++ b/src/GameSrc/vmail.c
@@ -433,8 +433,11 @@ errtype play_vmail(byte vmail_no)
 #ifndef CONTINUOUS_VMAIL_TEST
    if (!early_exit && vmail_wait_for_input)
       while (!citadel_check_input()) {
+         uiHideMouse(NULL); //trick to prevent
+         uiShowMouse(NULL); //  mouse pointer freeze
          pump_events();
          SDLDraw();
+         tight_loop(FALSE); //keep the music playing
       }
 #endif
 


### PR DESCRIPTION
Keep music playing and mouse pointer moving while waiting for input at end of vmail