### PR TITLE
 Portable prefs option + Add more settings to prefs

### DIFF
--- a/src/GameSrc/gamewrap.c
+++ b/src/GameSrc/gamewrap.c
@@ -314,7 +314,7 @@ errtype interpret_qvars(void) {
     recompute_digifx_level(QUESTVAR_GET(SFX_VOLUME_QVAR));
 #ifdef AUDIOLOGS
     recompute_audiolog_level(QUESTVAR_GET(ALOG_VOLUME_QVAR));
-    audiolog_setting = QUESTVAR_GET(ALOG_OPT_QVAR);
+    //audiolog_setting = QUESTVAR_GET(ALOG_OPT_QVAR); //moved to prefs file
 #endif
     fullscrn_vitals = QUESTVAR_GET(FULLSCRN_VITAL_QVAR);
     fullscrn_icons = QUESTVAR_GET(FULLSCRN_ICON_QVAR);

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -1957,7 +1957,7 @@ void options_screen_init(void) {
     standard_button_rect(&r, 0, 2, 2, 2);
     r.ul.x -= 2;
     multi_init(i, keys[i], REF_STR_OptionsText + 2, REF_STR_TerseText, REF_STR_TerseFeedback,
-               sizeof(player_struct.terseness), &player_struct.terseness, 2, NULL, &r);
+               sizeof(gShockPrefs.goMsgLength), &(gShockPrefs.goMsgLength), 2, NULL, &r);
     i++;
 
     i++;
@@ -2078,12 +2078,12 @@ void wrapper_start(void (*init)(void)) {
     fv = full_visible;
     full_visible = 0;
 #endif
+    render_run(); //move here to fix ghost mouse cursor
     uiHideMouse(NULL);
     if (full_game_3d) {
 #ifdef SVGA_SUPPORT
         uchar old_over = gr2ss_override;
 #endif
-        render_run();
         gr_push_canvas(grd_screen_canvas);
 #ifdef SVGA_SUPPORT
         gr2ss_override = OVERRIDE_ALL;

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -114,15 +114,24 @@ void SetDefaultPrefs(void) {
     SetShockGlobals();
 }
 
-static FILE *open_prefs(const char *mode) {
-    FILE *f = fopen(PREFS_FILENAME, mode);
-    if (f) return f;
+static char *GetPrefsPathFilename(void)
+{
+  static char filename[512];
 
-    char fullname[512];
-    char *path = SDL_GetPrefPath("Interrupt", "SystemShock");
-    snprintf(fullname, sizeof(fullname), "%s%s", path, PREFS_FILENAME);
-    free(path);
-    return fopen(fullname, mode);
+  FILE *f = fopen(PREFS_FILENAME, "r");
+  if (f != NULL)
+  {
+    fclose(f);
+    strcpy(filename, PREFS_FILENAME);
+  }
+  else
+  {
+    char *p = SDL_GetPrefPath("Interrupt", "SystemShock");
+    snprintf(filename, sizeof(filename), "%s%s", p, PREFS_FILENAME);
+    free(p);
+  }
+
+  return filename;
 }
 
 static char *trim(char *s) {
@@ -142,7 +151,7 @@ static bool is_true(const char *s) {
 //	  Locate the preferences file and load them to set our global pref settings.
 //--------------------------------------------------------------------
 OSErr LoadPrefs(void) {
-    FILE *f = open_prefs("r");
+    FILE *f = fopen(GetPrefsPathFilename(), "r");
     if (!f) {
         // file can't be open, write default preferences
         return SavePrefs();
@@ -222,7 +231,7 @@ OSErr LoadPrefs(void) {
 OSErr SavePrefs(void) {
     INFO("Saving preferences");
 
-    FILE *f = open_prefs("w");
+    FILE *f = fopen(GetPrefsPathFilename(), "w");
     if (!f) {
         printf("ERROR: Failed to open preferences file\n");
         return -1;
@@ -561,7 +570,7 @@ int FireKeys[MAX_FIRE_KEYS+1]; //see input.c
 
 
 
-char *GetKeybindsPathFilename(void)
+static char *GetKeybindsPathFilename(void)
 {
   static char filename[512];
 

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -115,11 +115,8 @@ void SetDefaultPrefs(void) {
 }
 
 static FILE *open_prefs(const char *mode) {
-    FILE *f = fopen("portable.txt", "r");
-    if (f) {
-        fclose(f);
-        return fopen(PREFS_FILENAME, mode);
-    }
+    FILE *f = fopen(PREFS_FILENAME, mode);
+    if (f) return f;
 
     char fullname[512];
     char *path = SDL_GetPrefPath("Interrupt", "SystemShock");
@@ -568,7 +565,7 @@ char *GetKeybindsPathFilename(void)
 {
   static char filename[512];
 
-  FILE *f = fopen("portable.txt", "r");
+  FILE *f = fopen(KEYBINDS_FILENAME, "r");
   if (f != NULL)
   {
     fclose(f);


### PR DESCRIPTION
If portable.txt file exists in game folder, prefs.txt and keybinds.txt will reside with it.

Add message length (normal/terse) and audiolog setting (text/audio/both) to prefs file. Don't load audiolog setting from saved game.

Fix message length button in options setting wrong variable.

Fix ghost mouse cursor when opening settings while cursor is in settings area in full 3d mode.