### PR TITLE
sq light intensity + make mutants invis in OpenGL

### DIFF
--- a/shaders/texture.frag
+++ b/shaders/texture.frag
@@ -26,7 +26,7 @@ void main() {
         gl_FragColor = vec4(rg, rg, b, (mutant ? 0.2 * alpha : alpha));
     } else {
         float emissive = t.a > 0.5 ? (t.a - 0.5) * 2.0 : 0.0;
-        float light = max(Light, emissive);
+        float light = max(Light * Light, emissive);
         if (mutant)
             gl_FragColor = vec4(0.5 * t.r * light, 0.5 * t.r * light, 0.5 * t.r * light, 0.2 * alpha);
         else

--- a/shaders/texture.frag
+++ b/shaders/texture.frag
@@ -10,6 +10,7 @@ varying float Light;
 
 uniform sampler2D tex;
 uniform bool nightsight;
+uniform bool mutant;
 
 void main() {
     vec4 t = texture2D(tex, TexCoords);
@@ -22,10 +23,13 @@ void main() {
         float gray = 0.40 * t.r + 0.59 * t.g + 0.11 * t.b;
         float rg = 0.7 * gray;
         float b = 0.75 * gray + 0.1;
-        gl_FragColor = vec4(rg, rg, b, alpha);
+        gl_FragColor = vec4(rg, rg, b, (mutant ? 0.2 * alpha : alpha));
     } else {
         float emissive = t.a > 0.5 ? (t.a - 0.5) * 2.0 : 0.0;
         float light = max(Light, emissive);
-        gl_FragColor = vec4(t.r * light, t.g * light, t.b * light, alpha);
+        if (mutant)
+            gl_FragColor = vec4(0.5 * t.r * light, 0.5 * t.r * light, 0.5 * t.r * light, 0.2 * alpha);
+        else
+            gl_FragColor = vec4(t.r * light, t.g * light, t.b * light, alpha);
     }
 }

--- a/src/Libraries/3D/Source/Bitmap.c
+++ b/src/Libraries/3D/Source/Bitmap.c
@@ -370,7 +370,7 @@ grs_vertex **g3_bitmap_common(grs_bitmap *bm, g3s_phandle p) {
         if (_g3d_enable_blend) {
 
             // only blend if no translucent or no compressed translucent bitmap
-            if ((bm->type != BMT_TLUC8) || (bm->flags != BMF_TLUC8)) {
+            if ((bm->type != BMT_TLUC8) && (bm->flags != BMF_TLUC8)) {
                 // check for bitmap width<polygon width, if so, blend
 
                 // MLA - have no idea how this code could ever work, so I'm trying my own code

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -56,6 +56,7 @@ struct Shader {
     GLint uniView;
     GLint uniProj;
     GLint uniNightSight;
+    GLint uniMutant;
     GLint tcAttrib;
     GLint lightAttrib;
     GLint colorAttrib;
@@ -215,6 +216,7 @@ static int CreateShader(const char *vertexShaderFile, const char *fragmentShader
     outShader->uniView = glGetUniformLocation(shaderProgram, "view");
     outShader->uniProj = glGetUniformLocation(shaderProgram, "proj");
     outShader->uniNightSight = glGetUniformLocation(shaderProgram, "nightsight");
+    outShader->uniMutant = glGetUniformLocation(shaderProgram, "mutant");
     outShader->tcAttrib = glGetAttribLocation(shaderProgram, "texcoords");
     outShader->lightAttrib = glGetAttribLocation(shaderProgram, "light");
     outShader->colorAttrib = glGetAttribLocation(shaderProgram, "color");
@@ -671,6 +673,8 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
         light = 1.0f - (clut - grd_screen->ltab) / 4096.0f;
     }
 
+    light *= light;
+
     if (tcAttrib >= 0)
         glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
     glVertexAttrib1f(lightAttrib, light);
@@ -753,7 +757,11 @@ int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) {
         // recalculate it from the offset into the global lighting lookup
         // table.
         light = 1.0 - (ti->clut - grd_screen->ltab) / 4096.0f;
+
+        light *= light;
     }
+
+    glUniform1i(textureShaderProgram.uniMutant, (bm->type == BMT_TLUC8) || (bm->flags == BMF_TLUC8));
 
     glBegin(GL_TRIANGLE_STRIP);
     glVertexAttrib2f(tcAttrib, 1.0f, 0.0f);
@@ -769,6 +777,8 @@ int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) {
     glVertexAttrib1f(lightAttrib, light);
     glVertex3f(convx(vpl[3]->x), convy(vpl[3]->y), 0.0f);
     glEnd();
+
+    glUniform1i(textureShaderProgram.uniMutant, false);
 
     return CLIP_NONE;
 }

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -673,8 +673,6 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
         light = 1.0f - (clut - grd_screen->ltab) / 4096.0f;
     }
 
-    light *= light;
-
     if (tcAttrib >= 0)
         glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
     glVertexAttrib1f(lightAttrib, light);
@@ -757,8 +755,6 @@ int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) {
         // recalculate it from the offset into the global lighting lookup
         // table.
         light = 1.0 - (ti->clut - grd_screen->ltab) / 4096.0f;
-
-        light *= light;
     }
 
     glUniform1i(textureShaderProgram.uniMutant, (bm->type == BMT_TLUC8) || (bm->flags == BMF_TLUC8));

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -303,6 +303,7 @@ void SetSDLPalette(int index, int count, uchar *pal)
   static uchar gammalut[100-10+1][256];
   if (!gammalut_init)
   {
+    double factor = (can_use_opengl() ? 1.0 : 2.2); //OpenGL uses 2.2
     int i, j;
     for (i = 10; i <= 100; i++)
     {
@@ -310,7 +311,7 @@ void SetSDLPalette(int index, int count, uchar *pal)
       gamma = 1 - gamma;
       gamma *= gamma;
       gamma = 1 - gamma;
-      gamma = 1 / gamma;
+      gamma = 1 / (gamma * factor);
       for (j = 0; j < 256; j++)
         gammalut[i-10][j] = (uchar)(pow((double)j / 255, gamma) * 255);
     }


### PR DESCRIPTION
Fix software invisible mutant disappears when near; see commit comment.

Square light intensity to make dark areas dark.

Add shader code to make OpenGL invisible mutants translucent.

