### PR TITLE
Fix building on MinGW.

### DIFF
--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -67,6 +67,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "cutsloop.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <SDL.h>
 


### PR DESCRIPTION
The #include is needed for `pow`.