### PR TITLE
Use SDL mixer 2.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,8 +326,8 @@ target_link_libraries(systemshock
 )
 
 if (WIN32)
-	include_directories(${CMAKE_SOURCE_DIR}/build_ext/glew-2.1.0/include)
-	target_link_libraries(systemshock ${CMAKE_SOURCE_DIR}/build_ext/glew-2.1.0/lib/libglew32.dll.a)
+	include_directories(${CMAKE_SOURCE_DIR}/build_ext/built_glew/include)
+	target_link_libraries(systemshock ${CMAKE_SOURCE_DIR}/build_ext/built_glew/lib/libglew32.dll.a)
 endif(WIN32)
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Compiling / Running
 
 ## Building SDL
 ### Linux/Mac
-You can use the included `build_deps.sh` shell script to build the required versions of SDL2 / SDL2_mixer. VOC support was broken until recently in SDL_mixer, so for sound effects to work you'll probably need to build it from the latest sources like that script does.
+You can use the included `build_deps.sh` shell script to build the required versions of SDL2 / SDL2_mixer. 
 
 ### Windows
 See [the Windows readme](windows/readme_windows.md).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
   APPVEYOR: TRUE
 
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)
-# Uncache build_ext if external deps change (eg. SDL_mixer 2.0.3 gets released)
+# Uncache build_ext if external deps change
 cache:
-  - build_ext  
+#  - build_ext  
 
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
@@ -38,7 +38,7 @@ after_build:
   - copy c:\mingw\bin\libstd*.dll .
   - copy build_ext\built_sdl\bin\SDL*.dll .
   - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
-  - copy build_ext\glew-2.1.0\lib\glew32.dll .
+  - copy build_ext\built_glew\lib\glew32.dll .
   - copy readme\readme-windows.txt readme.txt
   - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt shaders/
 

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-SDL_version=2.0.8
-SDL2_mixer_version=2.0.2
+SDL_version=2.0.9
+SDL2_mixer_version=2.0.4
 
 if [ -d ./build_ext/ ]; then
 	echo A directory named build_ext already exists.
@@ -31,8 +31,6 @@ function build_sdl_mixer {
 	curl -O https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${SDL2_mixer_version}.tar.gz
 	tar xvf SDL2_mixer-${SDL2_mixer_version}.tar.gz
 	pushd SDL2_mixer-${SDL2_mixer_version}
-	curl -O https://github.com/SDL-mirror/SDL_mixer/commit/7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
-	patch < 7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
 
   export SDL2_CONFIG="${install_dir}/built_sdl/bin/sdl2-config"
 	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=${install_dir}/built_sdl_mixer

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-SDL_version=2.0.8
-SDL2_mixer_version=2.0.2
+SDL_version=2.0.9
+SDL2_mixer_version=2.0.4
+GLEW_version=2.1.0
 CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
@@ -32,8 +33,6 @@ function build_sdl_mixer {
 	# the target of the link cannot be found at the time of the extraction.
 	tar xf SDL2_mixer-${SDL2_mixer_version}.tar.gz --exclude=Xcode
 	pushd SDL2_mixer-${SDL2_mixer_version}
-	curl -O https://github.com/SDL-mirror/SDL_mixer/commit/7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
-	patch < 7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
 
 	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" --host=i686-w64-mingw32 --disable-sdltest --with-sdl-prefix=${install_dir}/built_sdl --prefix=${install_dir}/built_sdl_mixer 
 	
@@ -45,9 +44,10 @@ function build_sdl_mixer {
 }
 
 function build_glew {
-	curl -O https://netcologne.dl.sourceforge.net/project/glew/glew/2.1.0/glew-2.1.0.tgz
-	tar xvf glew-2.1.0.tgz
-	pushd glew-2.1.0
+	curl -O https://netcologne.dl.sourceforge.net/project/glew/glew/${GLEW_version}/glew-${GLEW_version}.tgz
+	tar xvf glew-${GLEW_version}.tgz
+	mv glew-${GLEW_version}/ built_glew/
+	pushd built_glew
 	mingw32-make glew.lib
 	popd
 }
@@ -89,7 +89,7 @@ fi
 cd ..
 cp build_ext/built_sdl/bin/SDL*.dll .
 cp build_ext/built_sdl_mixer/bin/SDL*.dll .
-cp build_ext/glew-2.1.0/lib/*.dll .
+cp build_ext/built_glew/lib/*.dll .
 
 # Set up build.bat
 if [[ -z "${APPVEYOR}" ]]; then

--- a/osx-linux/install_32bit_sdl.sh
+++ b/osx-linux/install_32bit_sdl.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-SDL_version=2.0.8
-SDL2_mixer_version=2.0.2
+SDL_version=2.0.9
+SDL2_mixer_version=2.0.4
 
 function build_sdl {
 	curl -O https://www.libsdl.org/release/SDL2-${SDL_version}.tar.gz
@@ -21,8 +21,6 @@ function build_sdl_mixer {
 	curl -O https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${SDL2_mixer_version}.tar.gz
 	tar xf SDL2_mixer-${SDL2_mixer_version}.tar.gz
 	pushd SDL2_mixer-${SDL2_mixer_version}
-	curl -O https://github.com/SDL-mirror/SDL_mixer/commit/7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
-	patch < 7cad09d4d479df2b21b3e489f8e155bdf8254fd4.patch
 
 	export SDL2_CONFIG="/usr/local/bin/sdl2-config"
 	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32"


### PR DESCRIPTION
Update build scripts with most recent SDL and SDL mixer versions. This gets rid of the need to retrieve a patch for SDL mixer. 

As this changes the external dependencies on Windows, I'm turning off AppVeyor caching to make sure that the build succeeds on that platform. This also means that another AppVeyor cache purge and updating `appveyor.yml` to turn caching back on is needed after merging. I dug up the instructions on how to purge the cache from Discord:

```
AppVeyor uses bearer token authentication. Token can be found on API token page under your AppVeyor account.

Token must be set in Authorization header of every request to AppVeyor REST API:

Authorization: Bearer <token>
```

```
You can use AppVeyor REST API to delete build cache of specific project. Use CURL, Postman, Fiddler, PowerShell or your favorite web debugging tool to run the following query (with Authorization header of course):

DELETE https://ci.appveyor.com/api/projects/{accountName}/{projectSlug}/buildcache
```
