### PR TITLE
Support MIDI music based on FluidSynth backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ include_directories(
 message(STATUS "Found SDL2 Include:${SDL2_INCLUDE_DIRS} Library:${SDL2_LIBRARIES}")
 message(STATUS "Found SDL2_Mixer Include:${SDL2_MIXER_INCLUDE_DIRS} Library:${SDL2_MIXER_LIBRARIES}")
 
+# Find FluidSynth
+find_library(FLUIDSYNTH_LIBRARY fluidsynth)
+
 # for now I'll put a Carbon/Carbon.h into src/stubs/
 # that defines Mac-specific types and provides stubs for used functions
 # like GetResource()
@@ -73,6 +76,7 @@ set(MAC_SRC
 	src/MacSrc/Modding.c
 	src/MacSrc/OpenGL.cc
 	src/MacSrc/Xmi.c
+	src/MusicSrc/MusicDevice.c
 )
 
 set(GAME_SRC
@@ -214,6 +218,7 @@ include_directories(
 	src/Libraries/adlmidi/include
 	src/GameSrc/Headers
 	src/MacSrc
+	src/MusicSrc
 )
 
 if(ENABLE_EXAMPLES)
@@ -324,6 +329,11 @@ target_link_libraries(systemshock
 	${SDL2_MIXER_LIBRARIES}
 	${OPENGL_LIBRARIES}
 )
+
+if(FLUIDSYNTH_LIBRARY)
+  add_definitions("-DUSE_FLUIDSYNTH=1")
+  target_link_libraries(systemshock "${FLUIDSYNTH_LIBRARY}")
+endif()
 
 if (WIN32)
 	include_directories(${CMAKE_SOURCE_DIR}/build_ext/built_glew/include)

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -13,7 +13,7 @@ static Mix_Chunk *samples_by_channel[SND_MAX_SAMPLES];
 static snd_digi_parms digi_parms_by_channel[SND_MAX_SAMPLES];
 
 extern SDL_AudioStream *cutscene_audiostream;
-extern struct ADL_MIDIPlayer *adlD;
+extern struct MusicDevice *MusicDev;
 
 extern char *MusicCallbackBuffer;
 
@@ -45,7 +45,7 @@ int snd_start_digital(void) {
 
     MusicCallbackBuffer = (char *)malloc(2048*5); //larger than needed paranoia
 
-    Mix_HookMusic(MusicCallback, (void *)&adlD);
+    Mix_HookMusic(MusicCallback, (void *)&MusicDev);
 
 
 	InitReadXMI();

--- a/src/MacSrc/Xmi.c
+++ b/src/MacSrc/Xmi.c
@@ -15,11 +15,13 @@ char *MusicCallbackBuffer;
 
 void MusicCallback(void *userdata, Uint8 *stream, int len)
 {
-  MusicDevice *dev = *(MusicDevice **)userdata;
+  MusicDevice *dev;
+
+  SDL_LockMutex(MyMutex);
+  dev = *(MusicDevice **)userdata;
 
   if (dev != NULL)
   {
-    SDL_LockMutex(MyMutex);
     dev->generate(dev, (short *)MusicCallbackBuffer, len / (2 * sizeof(short)));
     SDL_UnlockMutex(MyMutex);
 
@@ -29,6 +31,8 @@ void MusicCallback(void *userdata, Uint8 *stream, int len)
     SDL_memset(stream, 0, len);
     SDL_MixAudioFormat(stream, MusicCallbackBuffer, AUDIO_S16SYS, len, volume);
   }
+  else
+    SDL_UnlockMutex(MyMutex);
 }
 
 

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -1,0 +1,360 @@
+#include "MusicDevice.h"
+#include <stdlib.h>
+#include <string.h>
+
+//------------------------------------------------------------------------------
+// Dummy MIDI player
+
+static int NullMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    return 0;
+}
+
+static void NullMidiDestroy(MusicDevice *dev)
+{
+    free(dev);
+}
+
+static void NullMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+}
+
+static void NullMidiReset(MusicDevice *dev)
+{
+}
+
+static void NullMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    memset(samples, 0, numframes * sizeof(short));
+}
+
+static void NullMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+}
+
+static void NullMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+}
+
+static void NullMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+}
+
+static void NullMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+}
+
+static void NullMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+}
+
+static void NullMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+}
+
+static void NullMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+}
+
+static MusicDevice *createNullMidiDevice()
+{
+    MusicDevice *dev = malloc(sizeof(MusicDevice));
+    dev->init = &NullMidiInit;
+    dev->destroy = &NullMidiDestroy;
+    dev->setupMode = &NullMidiSetupMode;
+    dev->reset = &NullMidiReset;
+    dev->generate = &NullMidiGenerate;
+    dev->sendNoteOff = &NullMidiSendNoteOff;
+    dev->sendNoteOn = &NullMidiSendNoteOn;
+    dev->sendNoteAfterTouch = &NullMidiSendNoteAfterTouch;
+    dev->sendControllerChange = &NullMidiSendControllerChange;
+    dev->sendProgramChange = &NullMidiSendProgramChange;
+    dev->sendChannelAfterTouch = &NullMidiSendChannelAfterTouch;
+    dev->sendPitchBendML = &NullMidiSendPitchBendML;
+    return dev;
+}
+
+//------------------------------------------------------------------------------
+// ADLMIDI player for OPL3
+
+#include "adlmidi.h"
+
+typedef struct AdlMidiDevice
+{
+    MusicDevice dev;
+    struct ADL_MIDIPlayer *adl;
+} AdlMidiDevice;
+
+static int AdlMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    struct ADL_MIDIPlayer *adl = adl_init(samplerate);
+
+    adl_switchEmulator(adl, ADLMIDI_EMU_NUKED_174);
+    adl_setNumChips(adl, 1);
+    adl_setVolumeRangeModel(adl, ADLMIDI_VolumeModel_AUTO);
+    adl_setRunAtPcmRate(adl, 1);
+
+    adev->adl = adl;
+    return 0;
+}
+
+static void AdlMidiDestroy(MusicDevice *dev)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_close(adev->adl);
+    free(adev);
+}
+
+static void AdlMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+
+    //Use sound bank 45 for res/sound/sblaster, 0 for res/sound/genmidi
+    adl_setBank(adev->adl, (mode == Music_SoundBlaster) ? 45 : 0);
+}
+
+static void AdlMidiReset(MusicDevice *dev)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_reset(adev->adl);
+}
+
+static void AdlMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_generate(adev->adl, 2 * numframes, samples);
+}
+
+static void AdlMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteOff(adev->adl, channel, note);
+    (void)vel;
+}
+
+static void AdlMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteOn(adev->adl, channel, note, vel);
+}
+
+static void AdlMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteAfterTouch(adev->adl, channel, note, touch);
+}
+
+static void AdlMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_controllerChange(adev->adl, channel, ctl, val);
+}
+
+static void AdlMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_patchChange(adev->adl, channel, pgm);
+}
+
+static void AdlMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_channelAfterTouch(adev->adl, channel, touch);
+}
+
+static void AdlMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_pitchBendML(adev->adl, channel, msb, lsb);
+}
+
+static MusicDevice *createAdlMidiDevice()
+{
+    AdlMidiDevice *adev = malloc(sizeof(AdlMidiDevice));
+    adev->dev.init = &AdlMidiInit;
+    adev->dev.destroy = &AdlMidiDestroy;
+    adev->dev.setupMode = &AdlMidiSetupMode;
+    adev->dev.reset = &AdlMidiReset;
+    adev->dev.generate = &AdlMidiGenerate;
+    adev->dev.sendNoteOff = &AdlMidiSendNoteOff;
+    adev->dev.sendNoteOn = &AdlMidiSendNoteOn;
+    adev->dev.sendNoteAfterTouch = &AdlMidiSendNoteAfterTouch;
+    adev->dev.sendControllerChange = &AdlMidiSendControllerChange;
+    adev->dev.sendProgramChange = &AdlMidiSendProgramChange;
+    adev->dev.sendChannelAfterTouch = &AdlMidiSendChannelAfterTouch;
+    adev->dev.sendPitchBendML = &AdlMidiSendPitchBendML;
+    return &adev->dev;
+}
+
+//------------------------------------------------------------------------------
+// FluidSynth soundfont synthesizer
+
+#ifdef USE_FLUIDSYNTH
+#include <fluidsynth.h>
+
+typedef struct FluidMidiDevice
+{
+    MusicDevice dev;
+    fluid_synth_t *synth;
+    fluid_settings_t *settings;
+} FluidMidiDevice;
+
+static int FluidMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_settings_t *settings;
+    fluid_synth_t *synth;
+    int sfid;
+
+    settings = new_fluid_settings();
+    fluid_settings_setnum(settings, "synth.sample-rate", samplerate);
+
+    synth = new_fluid_synth(settings);
+    sfid = fluid_synth_sfload(synth, "res/music.sf2", 1);
+
+    if (sfid == FLUID_FAILED)
+    {
+        WARN("cannot load res/music.sf2 for FluidSynth");
+        delete_fluid_synth(synth);
+        delete_fluid_settings(settings);
+        fdev->synth = NULL;
+        fdev->settings = NULL;
+        return -1;
+    }
+
+    fluid_synth_sfont_select(synth, 0, sfid);
+
+    fdev->synth = synth;
+    fdev->settings = settings;
+
+    return 0;
+}
+
+static void FluidMidiDestroy(MusicDevice *dev)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    delete_fluid_synth(fdev->synth);
+    delete_fluid_settings(fdev->settings);
+    free(dev);
+}
+
+static void FluidMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+    (void)dev;
+    (void)mode;
+}
+
+static void FluidMidiReset(MusicDevice *dev)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_system_reset(synth);
+}
+
+static void FluidMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_write_s16(synth, numframes,
+                          samples, 0, 2, /* left channel*/
+                          samples, 1, 2  /* right channel*/);
+}
+
+static void FluidMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_noteoff(synth, channel, note);
+    (void)vel;
+}
+
+static void FluidMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_noteon(synth, channel, note, vel);
+}
+
+static void FluidMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+#if FLUIDSYNTH_VERSION_MAJOR >= 2
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_key_pressure(synth, channel, note, touch);
+#else
+    (void)dev;
+    (void)channel;
+    (void)note;
+    (void)touch;
+#endif
+}
+
+static void FluidMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_cc(synth, channel, ctl, val);
+}
+
+static void FluidMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_program_change(synth, channel, pgm);
+}
+
+static void FluidMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_channel_pressure(synth, channel, touch);
+}
+
+static void FluidMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_pitch_bend(synth, channel, msb * 128 + lsb);
+}
+
+static MusicDevice *createFluidSynthDevice()
+{
+    FluidMidiDevice *adev = malloc(sizeof(FluidMidiDevice));
+    adev->dev.init = &FluidMidiInit;
+    adev->dev.destroy = &FluidMidiDestroy;
+    adev->dev.setupMode = &FluidMidiSetupMode;
+    adev->dev.reset = &FluidMidiReset;
+    adev->dev.generate = &FluidMidiGenerate;
+    adev->dev.sendNoteOff = &FluidMidiSendNoteOff;
+    adev->dev.sendNoteOn = &FluidMidiSendNoteOn;
+    adev->dev.sendNoteAfterTouch = &FluidMidiSendNoteAfterTouch;
+    adev->dev.sendControllerChange = &FluidMidiSendControllerChange;
+    adev->dev.sendProgramChange = &FluidMidiSendProgramChange;
+    adev->dev.sendChannelAfterTouch = &FluidMidiSendChannelAfterTouch;
+    adev->dev.sendPitchBendML = &FluidMidiSendPitchBendML;
+    return &adev->dev;
+}
+#endif // USE_FLUIDSYNTH
+
+//------------------------------------------------------------------------------
+MusicDevice *CreateMusicDevice(MusicType type)
+{
+    MusicDevice *dev;
+
+    switch (type)
+    {
+    default:
+        break;
+    case Music_AdlMidi:
+        dev = createAdlMidiDevice();
+        break;
+#ifdef USE_FLUIDSYNTH
+    case Music_FluidSynth:
+        dev = createFluidSynthDevice();
+        break;
+#endif
+    }
+
+    return dev;
+}

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -340,7 +340,7 @@ static MusicDevice *createFluidSynthDevice()
 //------------------------------------------------------------------------------
 MusicDevice *CreateMusicDevice(MusicType type)
 {
-    MusicDevice *dev;
+    MusicDevice *dev = NULL;
 
     switch (type)
     {

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -25,7 +25,7 @@ static void NullMidiReset(MusicDevice *dev)
 
 static void NullMidiGenerate(MusicDevice *dev, short *samples, int numframes)
 {
-    memset(samples, 0, numframes * sizeof(short));
+    memset(samples, 0, 2 * numframes * sizeof(short));
 }
 
 static void NullMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -346,6 +346,9 @@ MusicDevice *CreateMusicDevice(MusicType type)
     {
     default:
         break;
+    case Music_None:
+        dev = createNullMidiDevice();
+        break;
     case Music_AdlMidi:
         dev = createAdlMidiDevice();
         break;

--- a/src/MusicSrc/MusicDevice.h
+++ b/src/MusicSrc/MusicDevice.h
@@ -1,0 +1,37 @@
+#pragma once
+
+typedef struct MusicDevice MusicDevice;
+
+typedef enum MusicType
+{
+    Music_None,
+    Music_AdlMidi,
+    Music_FluidSynth,
+} MusicType;
+
+typedef enum MusicMode
+{
+    Music_GeneralMidi,
+    Music_SoundBlaster,
+} MusicMode;
+
+struct MusicDevice
+{
+    int (*init)(MusicDevice *dev, unsigned samplerate);
+    void (*destroy)(MusicDevice *dev);
+
+    void (*setupMode)(MusicDevice *dev, MusicMode mode);
+
+    void (*reset)(MusicDevice *dev);
+    void (*generate)(MusicDevice *dev, short *samples, int numframes);
+
+    void (*sendNoteOff)(MusicDevice *dev, int channel, int note, int vel);
+    void (*sendNoteOn)(MusicDevice *dev, int channel, int note, int vel);
+    void (*sendNoteAfterTouch)(MusicDevice *dev, int channel, int note, int touch);
+    void (*sendControllerChange)(MusicDevice *dev, int channel, int ctl, int val);
+    void (*sendProgramChange)(MusicDevice *dev, int channel, int pgm);
+    void (*sendChannelAfterTouch)(MusicDevice *dev, int channel, int touch);
+    void (*sendPitchBendML)(MusicDevice *dev, int channel, int msb, int lsb);
+};
+
+MusicDevice *CreateMusicDevice(MusicType type);


### PR DESCRIPTION
#277 

Permit music synthesis based on wavetables.
To make it work, build with FluidSynth and have a soundfont file of your choice in `res/music.sf2`.

If not present, I make it fall back on libADLMIDI as usual.

I put the source in a created directory `MusicSrc`. If this isn't right, it's possible to change as you think appropriate.