### PR TITLE
Add fluidsynth-lite to Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ include_directories(
 message(STATUS "Found SDL2 Include:${SDL2_INCLUDE_DIRS} Library:${SDL2_LIBRARIES}")
 message(STATUS "Found SDL2_Mixer Include:${SDL2_MIXER_INCLUDE_DIRS} Library:${SDL2_MIXER_LIBRARIES}")
 
+# Find FluidSynth
+find_library(FLUIDSYNTH_LIBRARY fluidsynth)
+
 # for now I'll put a Carbon/Carbon.h into src/stubs/
 # that defines Mac-specific types and provides stubs for used functions
 # like GetResource()
@@ -73,6 +76,7 @@ set(MAC_SRC
 	src/MacSrc/Modding.c
 	src/MacSrc/OpenGL.cc
 	src/MacSrc/Xmi.c
+	src/MusicSrc/MusicDevice.c
 )
 
 set(GAME_SRC
@@ -214,6 +218,7 @@ include_directories(
 	src/Libraries/adlmidi/include
 	src/GameSrc/Headers
 	src/MacSrc
+	src/MusicSrc
 )
 
 if(ENABLE_EXAMPLES)
@@ -324,6 +329,11 @@ target_link_libraries(systemshock
 	${SDL2_MIXER_LIBRARIES}
 	${OPENGL_LIBRARIES}
 )
+
+if(FLUIDSYNTH_LIBRARY)
+  add_definitions("-DUSE_FLUIDSYNTH=1")
+  target_link_libraries(systemshock "${FLUIDSYNTH_LIBRARY}")
+endif()
 
 if (WIN32)
 	include_directories(${CMAKE_SOURCE_DIR}/build_ext/built_glew/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ message(STATUS "Found SDL2 Include:${SDL2_INCLUDE_DIRS} Library:${SDL2_LIBRARIES
 message(STATUS "Found SDL2_Mixer Include:${SDL2_MIXER_INCLUDE_DIRS} Library:${SDL2_MIXER_LIBRARIES}")
 
 # Find FluidSynth
-find_library(FLUIDSYNTH_LIBRARY fluidsynth)
+find_library(FLUIDSYNTH_LIBRARY fluidsynth PATHS build_ext/fluidsynth-lite/src)
 
 # for now I'll put a Carbon/Carbon.h into src/stubs/
 # that defines Mac-specific types and provides stubs for used functions
@@ -331,8 +331,10 @@ target_link_libraries(systemshock
 )
 
 if(FLUIDSYNTH_LIBRARY)
+  message(STATUS "Fluidsynth found")
   add_definitions("-DUSE_FLUIDSYNTH=1")
   target_link_libraries(systemshock "${FLUIDSYNTH_LIBRARY}")
+  include_directories(${CMAKE_SOURCE_DIR}/build_ext/fluidsynth-lite/include)
 endif()
 
 if (WIN32)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ build_script:
   - mklink /D c:\git "C:\Program Files\Git"
   - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
   - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
+  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
   - sh build_windows.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,12 @@ environment:
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)
 # Uncache build_ext if external deps change
 cache:
+    - res/music.sf2
 #  - build_ext  
+
+# CMake refuses to generate MinGW Makefiles if sh.exe is in the Path
+install:
+    - ps: Get-Command sh.exe -All | Remove-Item
 
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
@@ -26,7 +31,7 @@ build_script:
   - set PATH=c:\git\usr\bin;%PATH%;C:\MinGW\bin
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
-  - sh build_windows.sh
+  - c:\git\bin\sh build_windows.sh
   - build.bat
 
 # For now, we don't have any automatic tests to run

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ cache:
 build_script:
   - mklink /D c:\git "C:\Program Files\Git"
   - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
-  - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
-  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\
+  - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
+  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
   - sh build_windows.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ environment:
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)
 # Uncache build_ext if external deps change
 cache:
-    - res/music.sf2
-#  - build_ext  
+  - res/music.sf2
+  - build_ext  
 
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,6 @@ cache:
     - res/music.sf2
 #  - build_ext  
 
-# CMake refuses to generate MinGW Makefiles if sh.exe is in the Path
-install:
-    - ps: Get-Command sh.exe -All | Remove-Item
-
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
 #         So we create a symlink to the real Git, remove it from PATH and add our own.
@@ -28,10 +24,10 @@ install:
 build_script:
   - mklink /D c:\git "C:\Program Files\Git"
   - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
-  - set PATH=c:\git\usr\bin;%PATH%;C:\MinGW\bin
+  - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
-  - c:\git\bin\sh build_windows.sh
+  - sh build_windows.sh
   - build.bat
 
 # For now, we don't have any automatic tests to run

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,9 @@ after_build:
   - copy build_ext\built_sdl\bin\SDL*.dll .
   - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
   - copy build_ext\built_glew\lib\glew32.dll .
+  - copy build_ext\fluidsynth-lite\src\libfluidsynth.dll .
   - copy readme\readme-windows.txt readme.txt
-  - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt shaders/
+  - 7z a systemshock-windows.zip systemshock.exe *.dll readme.txt shaders/ res/
 
 artifacts:
   - path: systemshock-windows.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ build_script:
   - mklink /D c:\git "C:\Program Files\Git"
   - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
   - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
-  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
   - sh build_windows.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ build_script:
   - mklink /D c:\git "C:\Program Files\Git"
   - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
   - set PATH=c:\git\usr\bin;%PATH%;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\bin
-  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\
+  - dir C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\
   - copy windows\make.exe \git\usr\bin
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
   - sh build_windows.sh

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -10,6 +10,10 @@ if [ -d ./build_ext/ ]; then
 	exit
 fi
 
+if [ ! -d ./res/ ]; then
+	mkdir ./res/
+fi
+
 mkdir ./build_ext/
 cd ./build_ext/
 
@@ -32,7 +36,7 @@ function build_sdl_mixer {
 	tar xvf SDL2_mixer-${SDL2_mixer_version}.tar.gz
 	pushd SDL2_mixer-${SDL2_mixer_version}
 
-  export SDL2_CONFIG="${install_dir}/built_sdl/bin/sdl2-config"
+	export SDL2_CONFIG="${install_dir}/built_sdl/bin/sdl2-config"
 	./configure "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=${install_dir}/built_sdl_mixer
 	make
 	make install
@@ -40,5 +44,25 @@ function build_sdl_mixer {
 	popd
 }
 
+function build_fluidsynth {
+	git clone https://github.com/Doom64/fluidsynth-lite.git
+	pushd fluidsynth-lite
+	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
+	# if building fluidsynth fails, move on without it
+	set +e
+	cmake .
+	cmake --build .
+
+	# download a soundfont that's close to the Windows default everyone knows
+	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
+	set -e
+	popd
+}
+
+
 build_sdl
 build_sdl_mixer
+build_fluidsynth
+
+cd ..
+mv build_ext/fluidsynth-lite/*.sf2 ./res

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -64,7 +64,7 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	cmake -G "${CMAKE_target}" .
+	cmake -G "MinGW Makefiles" .
 	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
@@ -102,16 +102,17 @@ mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
 
-build_sdl
-build_sdl_mixer
-build_glew
-
 if ! [ -x "$(command -v cmake)" ]; then
 	echo "Getting CMake"
 	get_cmake
 fi
 
 build_fluidsynth
+
+build_sdl
+build_sdl_mixer
+build_glew
+
 
 # Back to the root directory, copy required DLL files for the executable
 cd ..

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -64,8 +64,8 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	cmake -G "${CMAKE_target}" .
-	cmake --build . -- D_WIN32_WINNT=0x600
+	cmake -G "${CMAKE_target}" -DMINGW=1 .
+	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
 	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -8,11 +8,7 @@ CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
 
-if [[ -z "${APPVEYOR}" ]]; then
-	CMAKE_target=MinGW\ Makefiles
-else
-	CMAKE_target=Unix\ Makefiles
-fi
+CMAKE_target=MinGW\ Makefiles
 
 # Removing the mwindows linker option lets us get console output
 function remove_mwindows {
@@ -64,7 +60,7 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	cmake -G "${CMAKE_target}" -DMINGW=1 .
+	cmake -G "${CMAKE_target}"
 	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -7,8 +7,7 @@ GLEW_version=2.1.0
 CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
-
-	CMAKE_target=Unix\ Makefiles
+CMAKE_target=Unix\ Makefiles
 
 # Removing the mwindows linker option lets us get console output
 function remove_mwindows {
@@ -60,11 +59,11 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	cmake -G "${CMAKE_target}"
+	cmake -G "${CMAKE_target}" .
 	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
-	# curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
+	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
 	set -e
 	popd
 }

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -102,16 +102,17 @@ mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
 
-build_sdl
-build_sdl_mixer
-build_glew
-
 if ! [ -x "$(command -v cmake)" ]; then
 	echo "Getting CMake"
 	get_cmake
 fi
 
 build_fluidsynth
+
+build_sdl
+build_sdl_mixer
+build_glew
+
 
 # Back to the root directory, copy required DLL files for the executable
 cd ..

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -64,8 +64,8 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	cmake -G "MinGW Makefiles" .
-	cmake --build .
+	cmake -G "${CMAKE_target}" .
+	cmake --build . -- D_WIN32_WINNT=0x600
 
 	# download a soundfont that's close to the Windows default everyone knows
 	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
@@ -102,17 +102,16 @@ mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
 
+build_sdl
+build_sdl_mixer
+build_glew
+
 if ! [ -x "$(command -v cmake)" ]; then
 	echo "Getting CMake"
 	get_cmake
 fi
 
 build_fluidsynth
-
-build_sdl
-build_sdl_mixer
-build_glew
-
 
 # Back to the root directory, copy required DLL files for the executable
 cd ..

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -8,7 +8,11 @@ CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
 
-CMAKE_target=MinGW\ Makefiles
+if [[ -z "${APPVEYOR}" ]]; then
+	CMAKE_target=MinGW\ Makefiles
+else
+	CMAKE_target=Unix\ Makefiles
+fi
 
 # Removing the mwindows linker option lets us get console output
 function remove_mwindows {

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -8,11 +8,7 @@ CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
 
-if [[ -z "${APPVEYOR}" ]]; then
-	CMAKE_target=MinGW\ Makefiles
-else
 	CMAKE_target=Unix\ Makefiles
-fi
 
 # Removing the mwindows linker option lets us get console output
 function remove_mwindows {
@@ -68,7 +64,7 @@ function build_fluidsynth {
 	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
-	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
+	# curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
 	set -e
 	popd
 }

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -8,6 +8,12 @@ CMAKE_version=3.11.3
 #CMAKE_architecture=win64-x64
 CMAKE_architecture=win32-x86
 
+if [[ -z "${APPVEYOR}" ]]; then
+	CMAKE_target=MinGW\ Makefiles
+else
+	CMAKE_target=Unix\ Makefiles
+fi
+
 # Removing the mwindows linker option lets us get console output
 function remove_mwindows {
 	sed -i -e "s/ \-mwindows//g" Makefile
@@ -52,6 +58,21 @@ function build_glew {
 	popd
 }
 
+function build_fluidsynth {
+	git clone https://github.com/Doom64/fluidsynth-lite.git
+	pushd fluidsynth-lite
+	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
+	# if building fluidsynth fails, move on without it
+	set +e
+	cmake -G "${CMAKE_target}" .
+	cmake --build .
+
+	# download a soundfont that's close to the Windows default everyone knows
+	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
+	set -e
+	popd
+}
+
 function get_cmake {
 	curl -O https://cmake.org/files/v3.11/cmake-${CMAKE_version}-${CMAKE_architecture}.zip
 	unzip cmake-${CMAKE_version}-${CMAKE_architecture}.zip
@@ -72,6 +93,11 @@ rm -rf CMakeFiles/
 rm -rf CMakeCache.txt
 
 cp windows/make.exe /usr/bin/
+
+if [ ! -d ./res/ ]; then
+mkdir ./res/
+fi
+
 mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
@@ -85,22 +111,28 @@ if ! [ -x "$(command -v cmake)" ]; then
 	get_cmake
 fi
 
-# Back to the root directory, copy SDL DLL files for the executable
+build_fluidsynth
+
+# Back to the root directory, copy required DLL files for the executable
 cd ..
 cp build_ext/built_sdl/bin/SDL*.dll .
 cp build_ext/built_sdl_mixer/bin/SDL*.dll .
 cp build_ext/built_glew/lib/*.dll .
+cp build_ext/fluidsynth-lite/src/*.dll .
+
+# move the soundfont to the correct place if we successfully built fluidsynth
+mv build_ext/fluidsynth-lite/*.sf2 ./res
 
 # Set up build.bat
 if [[ -z "${APPVEYOR}" ]]; then
 	echo "Normal build"
 	echo "@echo off
 	set PATH=%PATH%;${CMAKE_ROOT}
-	cmake -G \"MinGW Makefiles\" .
+	cmake -G \"${CMAKE_target}\" .
 	mingw32-make systemshock" >build.bat
 else
 	echo "Appveyor"
-	echo "cmake -G \"Unix Makefiles\" . 
+	echo "cmake -G \"${CMAKE_target}\" . 
 	make systemshock" >build.bat
 fi
 

--- a/src/GameSrc/cutsloop.c
+++ b/src/GameSrc/cutsloop.c
@@ -69,6 +69,7 @@ extern char EngSubtitle[256];
 extern char FrnSubtitle[256];
 extern char GerSubtitle[256];
 
+extern SDL_AudioDeviceID device;
 
 
 extern void change_svga_screen_mode(void);
@@ -140,7 +141,7 @@ void cutscene_exit(void)
 
   if (cutscene_audiostream != NULL)
   {
-    SDL_PauseAudio(1);
+    SDL_PauseAudioDevice(device, 1);
     SDL_Delay(1);
 
     SDL_FreeAudioStream(cutscene_audiostream);
@@ -171,7 +172,7 @@ void cutscene_loop(void)
 
   if (cutscene_audiostream)
   {
-    SDL_PauseAudio(0);
+    SDL_PauseAudioDevice(device, 0);
   
     if (cutscene_audiobuffer_size > 0)
     {
@@ -307,7 +308,7 @@ short play_cutscene(int id, bool show_credits)
 
   if (sfx_on)
   {
-    SDL_PauseAudio(1);
+    SDL_PauseAudioDevice(device, 1);
     SDL_Delay(1);
 
     cutscene_audiostream = SDL_NewAudioStream(AUDIO_U8, 1, fix_int(amovie->a.sampleRate), AUDIO_S16SYS, 2, 48000);

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -32,8 +32,17 @@ int snd_start_digital(void) {
     spec.callback = AudioStreamCallback;
     spec.userdata = (void *)&cutscene_audiostream;
 
-    if (SDL_OpenAudio(&spec, &obtained)) {ERROR("Could not open SDL audio");}
-    else {INFO("Opened Music Stream");}
+    extern SDL_AudioDeviceID device;
+    device = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained, 0);
+
+    if (device == 0) {
+        ERROR("Could not open SDL audio");
+    } else {
+        INFO("Opened Music Stream, deviceID %d, freq %d, size %d, format %d, channels %d, samples %d", device,
+             obtained.freq, obtained.size, obtained.format, obtained.channels, obtained.samples);
+    }
+
+    SDL_PauseAudioDevice(device, 0);
 
 
     if (Mix_Init(MIX_INIT_MP3) < 0) {ERROR("%s: Init failed", __FUNCTION__);}

--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -13,7 +13,7 @@ static Mix_Chunk *samples_by_channel[SND_MAX_SAMPLES];
 static snd_digi_parms digi_parms_by_channel[SND_MAX_SAMPLES];
 
 extern SDL_AudioStream *cutscene_audiostream;
-extern struct ADL_MIDIPlayer *adlD;
+extern struct MusicDevice *MusicDev;
 
 extern char *MusicCallbackBuffer;
 
@@ -45,7 +45,7 @@ int snd_start_digital(void) {
 
     MusicCallbackBuffer = (char *)malloc(2048*5); //larger than needed paranoia
 
-    Mix_HookMusic(MusicCallback, (void *)&adlD);
+    Mix_HookMusic(MusicCallback, (void *)&MusicDev);
 
 
 	InitReadXMI();

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -97,6 +97,8 @@ SDL_Window* window;
 SDL_Palette* sdlPalette;
 SDL_Renderer* renderer;
 
+SDL_AudioDeviceID device;
+
 char window_title[128];
 int num_args;
 char** arg_values;

--- a/src/MacSrc/Xmi.c
+++ b/src/MacSrc/Xmi.c
@@ -15,11 +15,13 @@ char *MusicCallbackBuffer;
 
 void MusicCallback(void *userdata, Uint8 *stream, int len)
 {
-  MusicDevice *dev = *(MusicDevice **)userdata;
+  MusicDevice *dev;
+
+  SDL_LockMutex(MyMutex);
+  dev = *(MusicDevice **)userdata;
 
   if (dev != NULL)
   {
-    SDL_LockMutex(MyMutex);
     dev->generate(dev, (short *)MusicCallbackBuffer, len / (2 * sizeof(short)));
     SDL_UnlockMutex(MyMutex);
 
@@ -29,6 +31,8 @@ void MusicCallback(void *userdata, Uint8 *stream, int len)
     SDL_memset(stream, 0, len);
     SDL_MixAudioFormat(stream, MusicCallbackBuffer, AUDIO_S16SYS, len, volume);
   }
+  else
+    SDL_UnlockMutex(MyMutex);
 }
 
 

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -1,0 +1,360 @@
+#include "MusicDevice.h"
+#include <stdlib.h>
+#include <string.h>
+
+//------------------------------------------------------------------------------
+// Dummy MIDI player
+
+static int NullMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    return 0;
+}
+
+static void NullMidiDestroy(MusicDevice *dev)
+{
+    free(dev);
+}
+
+static void NullMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+}
+
+static void NullMidiReset(MusicDevice *dev)
+{
+}
+
+static void NullMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    memset(samples, 0, numframes * sizeof(short));
+}
+
+static void NullMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+}
+
+static void NullMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+}
+
+static void NullMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+}
+
+static void NullMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+}
+
+static void NullMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+}
+
+static void NullMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+}
+
+static void NullMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+}
+
+static MusicDevice *createNullMidiDevice()
+{
+    MusicDevice *dev = malloc(sizeof(MusicDevice));
+    dev->init = &NullMidiInit;
+    dev->destroy = &NullMidiDestroy;
+    dev->setupMode = &NullMidiSetupMode;
+    dev->reset = &NullMidiReset;
+    dev->generate = &NullMidiGenerate;
+    dev->sendNoteOff = &NullMidiSendNoteOff;
+    dev->sendNoteOn = &NullMidiSendNoteOn;
+    dev->sendNoteAfterTouch = &NullMidiSendNoteAfterTouch;
+    dev->sendControllerChange = &NullMidiSendControllerChange;
+    dev->sendProgramChange = &NullMidiSendProgramChange;
+    dev->sendChannelAfterTouch = &NullMidiSendChannelAfterTouch;
+    dev->sendPitchBendML = &NullMidiSendPitchBendML;
+    return dev;
+}
+
+//------------------------------------------------------------------------------
+// ADLMIDI player for OPL3
+
+#include "adlmidi.h"
+
+typedef struct AdlMidiDevice
+{
+    MusicDevice dev;
+    struct ADL_MIDIPlayer *adl;
+} AdlMidiDevice;
+
+static int AdlMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    struct ADL_MIDIPlayer *adl = adl_init(samplerate);
+
+    adl_switchEmulator(adl, ADLMIDI_EMU_NUKED_174);
+    adl_setNumChips(adl, 1);
+    adl_setVolumeRangeModel(adl, ADLMIDI_VolumeModel_AUTO);
+    adl_setRunAtPcmRate(adl, 1);
+
+    adev->adl = adl;
+    return 0;
+}
+
+static void AdlMidiDestroy(MusicDevice *dev)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_close(adev->adl);
+    free(adev);
+}
+
+static void AdlMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+
+    //Use sound bank 45 for res/sound/sblaster, 0 for res/sound/genmidi
+    adl_setBank(adev->adl, (mode == Music_SoundBlaster) ? 45 : 0);
+}
+
+static void AdlMidiReset(MusicDevice *dev)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_reset(adev->adl);
+}
+
+static void AdlMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_generate(adev->adl, 2 * numframes, samples);
+}
+
+static void AdlMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteOff(adev->adl, channel, note);
+    (void)vel;
+}
+
+static void AdlMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteOn(adev->adl, channel, note, vel);
+}
+
+static void AdlMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_noteAfterTouch(adev->adl, channel, note, touch);
+}
+
+static void AdlMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_controllerChange(adev->adl, channel, ctl, val);
+}
+
+static void AdlMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_patchChange(adev->adl, channel, pgm);
+}
+
+static void AdlMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_channelAfterTouch(adev->adl, channel, touch);
+}
+
+static void AdlMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+    AdlMidiDevice *adev = (AdlMidiDevice *)dev;
+    adl_rt_pitchBendML(adev->adl, channel, msb, lsb);
+}
+
+static MusicDevice *createAdlMidiDevice()
+{
+    AdlMidiDevice *adev = malloc(sizeof(AdlMidiDevice));
+    adev->dev.init = &AdlMidiInit;
+    adev->dev.destroy = &AdlMidiDestroy;
+    adev->dev.setupMode = &AdlMidiSetupMode;
+    adev->dev.reset = &AdlMidiReset;
+    adev->dev.generate = &AdlMidiGenerate;
+    adev->dev.sendNoteOff = &AdlMidiSendNoteOff;
+    adev->dev.sendNoteOn = &AdlMidiSendNoteOn;
+    adev->dev.sendNoteAfterTouch = &AdlMidiSendNoteAfterTouch;
+    adev->dev.sendControllerChange = &AdlMidiSendControllerChange;
+    adev->dev.sendProgramChange = &AdlMidiSendProgramChange;
+    adev->dev.sendChannelAfterTouch = &AdlMidiSendChannelAfterTouch;
+    adev->dev.sendPitchBendML = &AdlMidiSendPitchBendML;
+    return &adev->dev;
+}
+
+//------------------------------------------------------------------------------
+// FluidSynth soundfont synthesizer
+
+#ifdef USE_FLUIDSYNTH
+#include <fluidsynth.h>
+
+typedef struct FluidMidiDevice
+{
+    MusicDevice dev;
+    fluid_synth_t *synth;
+    fluid_settings_t *settings;
+} FluidMidiDevice;
+
+static int FluidMidiInit(MusicDevice *dev, unsigned samplerate)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_settings_t *settings;
+    fluid_synth_t *synth;
+    int sfid;
+
+    settings = new_fluid_settings();
+    fluid_settings_setnum(settings, "synth.sample-rate", samplerate);
+
+    synth = new_fluid_synth(settings);
+    sfid = fluid_synth_sfload(synth, "res/music.sf2", 1);
+
+    if (sfid == FLUID_FAILED)
+    {
+        WARN("cannot load res/music.sf2 for FluidSynth");
+        delete_fluid_synth(synth);
+        delete_fluid_settings(settings);
+        fdev->synth = NULL;
+        fdev->settings = NULL;
+        return -1;
+    }
+
+    fluid_synth_sfont_select(synth, 0, sfid);
+
+    fdev->synth = synth;
+    fdev->settings = settings;
+
+    return 0;
+}
+
+static void FluidMidiDestroy(MusicDevice *dev)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    delete_fluid_synth(fdev->synth);
+    delete_fluid_settings(fdev->settings);
+    free(dev);
+}
+
+static void FluidMidiSetupMode(MusicDevice *dev, MusicMode mode)
+{
+    (void)dev;
+    (void)mode;
+}
+
+static void FluidMidiReset(MusicDevice *dev)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_system_reset(synth);
+}
+
+static void FluidMidiGenerate(MusicDevice *dev, short *samples, int numframes)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_write_s16(synth, numframes,
+                          samples, 0, 2, /* left channel*/
+                          samples, 1, 2  /* right channel*/);
+}
+
+static void FluidMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_noteoff(synth, channel, note);
+    (void)vel;
+}
+
+static void FluidMidiSendNoteOn(MusicDevice *dev, int channel, int note, int vel)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_noteon(synth, channel, note, vel);
+}
+
+static void FluidMidiSendNoteAfterTouch(MusicDevice *dev, int channel, int note, int touch)
+{
+#if FLUIDSYNTH_VERSION_MAJOR >= 2
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_key_pressure(synth, channel, note, touch);
+#else
+    (void)dev;
+    (void)channel;
+    (void)note;
+    (void)touch;
+#endif
+}
+
+static void FluidMidiSendControllerChange(MusicDevice *dev, int channel, int ctl, int val)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_cc(synth, channel, ctl, val);
+}
+
+static void FluidMidiSendProgramChange(MusicDevice *dev, int channel, int pgm)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_program_change(synth, channel, pgm);
+}
+
+static void FluidMidiSendChannelAfterTouch(MusicDevice *dev, int channel, int touch)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_channel_pressure(synth, channel, touch);
+}
+
+static void FluidMidiSendPitchBendML(MusicDevice *dev, int channel, int msb, int lsb)
+{
+    FluidMidiDevice *fdev = (FluidMidiDevice *)dev;
+    fluid_synth_t *synth = fdev->synth;
+    fluid_synth_pitch_bend(synth, channel, msb * 128 + lsb);
+}
+
+static MusicDevice *createFluidSynthDevice()
+{
+    FluidMidiDevice *adev = malloc(sizeof(FluidMidiDevice));
+    adev->dev.init = &FluidMidiInit;
+    adev->dev.destroy = &FluidMidiDestroy;
+    adev->dev.setupMode = &FluidMidiSetupMode;
+    adev->dev.reset = &FluidMidiReset;
+    adev->dev.generate = &FluidMidiGenerate;
+    adev->dev.sendNoteOff = &FluidMidiSendNoteOff;
+    adev->dev.sendNoteOn = &FluidMidiSendNoteOn;
+    adev->dev.sendNoteAfterTouch = &FluidMidiSendNoteAfterTouch;
+    adev->dev.sendControllerChange = &FluidMidiSendControllerChange;
+    adev->dev.sendProgramChange = &FluidMidiSendProgramChange;
+    adev->dev.sendChannelAfterTouch = &FluidMidiSendChannelAfterTouch;
+    adev->dev.sendPitchBendML = &FluidMidiSendPitchBendML;
+    return &adev->dev;
+}
+#endif // USE_FLUIDSYNTH
+
+//------------------------------------------------------------------------------
+MusicDevice *CreateMusicDevice(MusicType type)
+{
+    MusicDevice *dev;
+
+    switch (type)
+    {
+    default:
+        break;
+    case Music_AdlMidi:
+        dev = createAdlMidiDevice();
+        break;
+#ifdef USE_FLUIDSYNTH
+    case Music_FluidSynth:
+        dev = createFluidSynthDevice();
+        break;
+#endif
+    }
+
+    return dev;
+}

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -340,7 +340,7 @@ static MusicDevice *createFluidSynthDevice()
 //------------------------------------------------------------------------------
 MusicDevice *CreateMusicDevice(MusicType type)
 {
-    MusicDevice *dev;
+    MusicDevice *dev = NULL;
 
     switch (type)
     {

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -25,7 +25,7 @@ static void NullMidiReset(MusicDevice *dev)
 
 static void NullMidiGenerate(MusicDevice *dev, short *samples, int numframes)
 {
-    memset(samples, 0, numframes * sizeof(short));
+    memset(samples, 0, 2 * numframes * sizeof(short));
 }
 
 static void NullMidiSendNoteOff(MusicDevice *dev, int channel, int note, int vel)

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -346,6 +346,9 @@ MusicDevice *CreateMusicDevice(MusicType type)
     {
     default:
         break;
+    case Music_None:
+        dev = createNullMidiDevice();
+        break;
     case Music_AdlMidi:
         dev = createAdlMidiDevice();
         break;

--- a/src/MusicSrc/MusicDevice.h
+++ b/src/MusicSrc/MusicDevice.h
@@ -1,0 +1,37 @@
+#pragma once
+
+typedef struct MusicDevice MusicDevice;
+
+typedef enum MusicType
+{
+    Music_None,
+    Music_AdlMidi,
+    Music_FluidSynth,
+} MusicType;
+
+typedef enum MusicMode
+{
+    Music_GeneralMidi,
+    Music_SoundBlaster,
+} MusicMode;
+
+struct MusicDevice
+{
+    int (*init)(MusicDevice *dev, unsigned samplerate);
+    void (*destroy)(MusicDevice *dev);
+
+    void (*setupMode)(MusicDevice *dev, MusicMode mode);
+
+    void (*reset)(MusicDevice *dev);
+    void (*generate)(MusicDevice *dev, short *samples, int numframes);
+
+    void (*sendNoteOff)(MusicDevice *dev, int channel, int note, int vel);
+    void (*sendNoteOn)(MusicDevice *dev, int channel, int note, int vel);
+    void (*sendNoteAfterTouch)(MusicDevice *dev, int channel, int note, int touch);
+    void (*sendControllerChange)(MusicDevice *dev, int channel, int ctl, int val);
+    void (*sendProgramChange)(MusicDevice *dev, int channel, int pgm);
+    void (*sendChannelAfterTouch)(MusicDevice *dev, int channel, int touch);
+    void (*sendPitchBendML)(MusicDevice *dev, int channel, int msb, int lsb);
+};
+
+MusicDevice *CreateMusicDevice(MusicType type);


### PR DESCRIPTION
Building on top of https://github.com/Interrupt/systemshock/pull/278, this incorporates the fluidsynth-lite library into the Windows build sequence -- and tries to do so for the generic `build_deps.sh`, further testing and finetuning is probably needed there. Further, it adds the Windows default soundfont as a downloaded default resource. 

As always, a change to `build_ext` requires an Appveyor cache flush.

Note that I didn't touch `travis.yml` as I think the whole process of building the distributable there needs some love from a person with a better grasp of the Linux/OSX world. The big question is whether we should have a separate build file for those environments over the general `build_deps.sh`, and how to handle the library dependencies in general.