### PR TITLE
Add native MIDI support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ savgam*.dat
 
 # Temporary audio files
 .temp.audio
+
+# Eclipse CDT
+.project
+.cproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,18 @@ project(SystemShock)
 cmake_minimum_required(VERSION 3.1)
 
 set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS ON)
 
 # Required for stdbool.h
 set(CMAKE_C_STANDARD 99)
 
 # hide Windows console in distributable packages
-if(DEFINED ENV{APPVEYOR}) 
+if(DEFINED ENV{APPVEYOR})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -O3 -mwindows")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -O3 -mwindows -D__STDC_LIMIT_MACROS")
 endif()
 
-if(NOT DEFINED ENV{APPVEYOR}) 
+if(NOT DEFINED ENV{APPVEYOR})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -D__STDC_LIMIT_MACROS")
 endif()
@@ -75,6 +76,18 @@ message(STATUS "Found SDL2_Mixer Include:${SDL2_MIXER_INCLUDE_DIRS} Library:${SD
 
 # Find FluidSynth
 find_library(FLUIDSYNTH_LIBRARY fluidsynth PATHS build_ext/fluidsynth-lite/src)
+
+if(NOT WIN32)
+  # Find ALSA for Linux native MIDI
+  # NOTE: this seems to require having 64-bit dev pacakges installed when building
+  #  on 64-bit OS, even when building a 32-bit binary
+  find_package(ALSA)
+  if(ALSA_FOUND)
+      message(STATUS "ALSA found")
+      include_directories(${ALSA_INCLUDE_DIRS})
+      add_definitions(-DUSE_ALSA=1)
+  endif(ALSA_FOUND)
+endif(NOT WIN32)
 
 # for now I'll put a Carbon/Carbon.h into src/stubs/
 # that defines Mac-specific types and provides stubs for used functions
@@ -347,6 +360,7 @@ target_link_libraries(systemshock
 	${SDL2_LIBRARIES}
 	${SDL2_MIXER_LIBRARIES}
 	${OPENGL_LIBRARIES}
+	${ALSA_LIBRARIES}
 )
 
 if(FLUIDSYNTH_LIBRARY)
@@ -360,7 +374,6 @@ if (WIN32)
         include_directories(${CMAKE_SOURCE_DIR}/build_ext/built_glew/include)
         target_link_libraries(systemshock ${CMAKE_SOURCE_DIR}/build_ext/built_glew/lib/libglew32.dll.a winmm)
 endif(WIN32)
-
 
 # Turn on address sanitizing if wanted
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers/cmake" ${CMAKE_MODULE_PATH})

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -1502,13 +1502,20 @@ void soundopt_screen_init() {
     i++;
 */
     unsigned int midiOutputCount = GetOutputCountXMI();
-    if (midiOutputCount > 0)
+    if (midiOutputCount > 1)
     {
         standard_slider_rect(&r, i, 2, 5);
         // this makes it double-wide i guess?
         r.lr.x += (r.lr.x - r.ul.x);
         slider_init(i, REF_STR_MidiOutX + gShockPrefs.soMidiOutput, sizeof(gShockPrefs.soMidiOutput), FALSE, &gShockPrefs.soMidiOutput, midiOutputCount - 1,
                     0, midi_output_dealfunc, &r);
+        i++;
+    }
+    else if (midiOutputCount == 1)
+    {
+        // just show a text label
+        standard_button_rect(&r, i, 1, 2, 10);
+        textwidget_init(i, BUTTON_COLOR, REF_STR_MidiOutX, &r);
         i++;
     }
 

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -531,7 +531,15 @@ void slider_init(uchar butid, Ref descrip, uchar type, uchar smooth, void *var, 
     opt_slider_state *st = (opt_slider_state *)&OButtons[butid].user;
     uint val;
 
-    val = ((r->lr.x - r->ul.x - 3) * multi_get_curval(type, var)) / maxval;
+    if (maxval)
+    {
+        val = ((r->lr.x - r->ul.x - 3) * multi_get_curval(type, var)) / maxval;
+    }
+    else
+    {
+        // just put it in the middle
+        val = (r->lr.x - r->ul.x - 3) / 2;
+    }
 
     st->color = BUTTON_COLOR;
     st->bvalcol = GREEN_YELLOW_BASE + 1;
@@ -1492,12 +1500,12 @@ void soundopt_screen_init() {
                sizeof(gShockPrefs.soMidiOutput), &gShockPrefs.soMidiOutput, numMidiOutputs, midi_output_dealfunc, &r);
     i++;
 */
-    standard_slider_rect(&r, i, 2, 5);
-    // this makes it double-wide i guess?
-    r.lr.x += (r.lr.x - r.ul.x);
     unsigned int midiOutputCount = GetOutputCountXMI();
-    if (midiOutputCount > 1)
+    if (midiOutputCount > 0)
     {
+        standard_slider_rect(&r, i, 2, 5);
+        // this makes it double-wide i guess?
+        r.lr.x += (r.lr.x - r.ul.x);
         slider_init(i, REF_STR_MidiOutX + gShockPrefs.soMidiOutput, sizeof(gShockPrefs.soMidiOutput), FALSE, &gShockPrefs.soMidiOutput, midiOutputCount - 1,
                     0, midi_output_dealfunc, &r);
         i++;


### PR DESCRIPTION
Implemented Linux support for native MIDI music driver, via the ALSA sequencer API.

Tested in an Ubuntu VM with various software synthesizers that provide ALSA sequencer devices (Fluidsynth via Qsynth, Timidity, Yoshimi).