### PR TITLE
Fix Travis packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ before_deploy:
   - cp osx-linux/install_32bit_sdl.sh shockolate
   - cp osx-linux/readme_osx_linux.md shockolate
   - cp osx-linux/run_$TRAVIS_OS_NAME.sh shockolate/run.sh
-  - cat shockolate/run.sh
   - cp -r shaders shockolate/
-  - cp readme/readme-linux.txt shockolate/readme.txt
+  - cp -r lib shockolate/
+  - cp -r res shockolate/
+  - cp readme/readme-$TRAVIS_OS_NAME.txt shockolate/readme.txt
   - tar zcfv $PACKAGE_NAME shockolate
   - rm -r shockolate
 


### PR DESCRIPTION
Fix the omission of the latest additions to the Travis artifacts: the 30MB Windows-like soundfont and an experimental set of precompiled libraries. 

After this, the Linux and OSX packages should theoretically be close to being able to start up by simply executing `./run.sh`.