### PR TITLE
Use enums instead of defines for synth settings

### DIFF
--- a/src/GameSrc/Headers/wrapper.h
+++ b/src/GameSrc/Headers/wrapper.h
@@ -81,4 +81,20 @@ extern char comments[NUM_SAVE_SLOTS][SAVE_COMMENT_LEN];
         save_game_name[7] = '0' + (game_num & 7);  \
     }
 
+enum TEMP_STR_ {
+        REF_STR_Renderer = 0x10000000,
+        REF_STR_Software,
+        REF_STR_OpenGL,
+
+        REF_STR_Seqer = 0x20000000,
+        REF_STR_ADLMIDI,
+        REF_STR_NativeMI,
+#ifdef USE_FLUIDSYNTH
+        REF_STR_FluidSyn,
+#endif // USE_FLUIDSYNTH
+        REF_STR_MidiOut = 0x2fffffff,
+
+        REF_STR_MidiOutX = 0x30000000 // 0x30000000-0x3fffffff are MIDI outputs
+};
+
 #endif // __WRAPPER_H

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -358,20 +358,8 @@ uchar fv;
 // override get_temp_string() to support hard-coded custom strings without
 // providing an actual resource file
 
-#define REF_STR_Renderer 0x10000000
-#define REF_STR_Software 0x10000001
-#define REF_STR_OpenGL   0x10000002
-
-#define REF_STR_Seqer    0x20000000
-#define REF_STR_ADLMIDI  0x20000001
-#define REF_STR_NativeMI 0x20000002
-#define REF_STR_FluidSyn 0x20000003 // this has to be last because it is optional
-#define REF_STR_MidiOut  0x2fffffff
-
-#define REF_STR_MidiOutX 0x30000000 // 0x30000000-0x3fffffff are MIDI outputs
-
-#define MIDI_OUT_BUFFER_SIZE 1024
-static char MIDI_OUT_BUFFER[MIDI_OUT_BUFFER_SIZE];
+#define MIDI_OUT_STR_SIZE 1024
+static char MIDI_STR_BUFFER[MIDI_OUT_STR_SIZE];
 
 static char *_get_temp_string(int num) {
     switch (num) {
@@ -382,7 +370,9 @@ static char *_get_temp_string(int num) {
         case REF_STR_Seqer:    return "Midi Player";
         case REF_STR_ADLMIDI:  return "ADLMIDI";
         case REF_STR_NativeMI: return "Native MIDI";
+#ifdef USE_FLUIDSYNTH
         case REF_STR_FluidSyn: return "FluidSynth";
+#endif
 
         case REF_STR_MidiOut:  return "Midi Output";
     }
@@ -390,9 +380,9 @@ static char *_get_temp_string(int num) {
     if (num >= REF_STR_MidiOutX && num <= (REF_STR_MidiOutX | 0x0fffffff))
     {
         const unsigned int midiOutputIndex = (unsigned int)num - REF_STR_MidiOutX;
-        MIDI_OUT_BUFFER[0] = '\0';
-        GetOutputNameXMI(midiOutputIndex, &MIDI_OUT_BUFFER[0], MIDI_OUT_BUFFER_SIZE);
-        return &MIDI_OUT_BUFFER[0];
+        MIDI_STR_BUFFER[0] = '\0';
+        GetOutputNameXMI(midiOutputIndex, &MIDI_STR_BUFFER[0], MIDI_OUT_STR_SIZE);
+        return &MIDI_STR_BUFFER[0];
     }
 
     return get_temp_string(num);
@@ -1484,14 +1474,9 @@ void soundopt_screen_init() {
     i++;
 #endif
 
-#ifdef USE_FLUIDSYNTH
-    const uchar numSynths = 3;
-#else
-    const uchar numSynths = 2;
-#endif
     standard_button_rect(&r, i, 2, 2, 5);
     multi_init(i, 'p', REF_STR_Seqer, REF_STR_ADLMIDI, ID_NULL,
-               sizeof(gShockPrefs.soMidiBackend), &gShockPrefs.soMidiBackend, numSynths, seqer_dealfunc, &r);
+               sizeof(gShockPrefs.soMidiBackend), &gShockPrefs.soMidiBackend, OPT_SEQ_Max, seqer_dealfunc, &r);
     i++;
 /* standard button is too narrow, so use a slider instead
     const unsigned int numMidiOutputs = GetOutputCountXMI();

--- a/src/MacSrc/Prefs.h
+++ b/src/MacSrc/Prefs.h
@@ -70,3 +70,15 @@ extern ShockPrefs gShockPrefs;
 void SetDefaultPrefs(void);
 OSErr LoadPrefs(void);
 OSErr SavePrefs(void);
+
+//-------------------
+//  Enums
+//-------------------
+enum OPT_SEQ_ { // Must be in the same order as in wraper.h
+        OPT_SEQ_ADLMIDI = 0,
+        OPT_SEQ_NativeMI,
+#ifdef USE_FLUIDSYNTH
+        OPT_SEQ_FluidSyn,
+#endif // USE_FLUIDSYNTH
+        OPT_SEQ_Max
+};

--- a/src/MacSrc/Xmi.c
+++ b/src/MacSrc/Xmi.c
@@ -661,20 +661,20 @@ void InitDecXMI(void)
 
   switch (gShockPrefs.soMidiBackend)
   {
-    case 0: // adlmidi
+    case OPT_SEQ_ADLMIDI: // adlmidi
     {
       INFO("Creating ADLMIDI device");
       musicdev = CreateMusicDevice(Music_AdlMidi);
     }
     break;
-    case 1: // native midi
+    case OPT_SEQ_NativeMI: // native midi
     {
       INFO("Creating native MIDI device");
       musicdev = CreateMusicDevice(Music_Native);
     }
     break;
 #ifdef USE_FLUIDSYNTH
-    case 2: // fluidsynth
+    case OPT_SEQ_FluidSyn: // fluidsynth
     {
       INFO("Creating FluidSynth MIDI device");
       musicdev = CreateMusicDevice(Music_FluidSynth);


### PR DESCRIPTION
I feel this is a cleaner way of doing it. If you disagree, let me know.