### PR TITLE
Improve mouse focus logic

### DIFF
--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -266,7 +266,7 @@ void SetMouseXY(int mx, int my)
 	}
 
 	bool inside = (mx >= x && mx < x+w && my >= y && my < y+h);
-	bool focus = (SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS);
+	bool focus = (SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_FOCUS);
 
 	if (!inside && focus)
 	{


### PR DESCRIPTION
Now the Shockolate mouse cursor should follow/replace the OS mouse cursor whenever the mouse points at the Shockolate window.