### PR TITLE
Include version and revision from project and git history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(SystemShock)
-
 cmake_minimum_required(VERSION 3.1)
+
+project(shockolate VERSION 0.7.8)
 
 include(FeatureSummary)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,8 @@ if(GIT_FOUND)
 endif(GIT_FOUND)
 
 message(STATUS "Version is ${PROJECT_VERSION}${PROJECT_REVERSION_STRING}")
-configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/version.h.in" "${CMAKE_BINARY_DIR}/src/GameSrc/Headers/version.h" )
+configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/shockolate_version.h.in"
+	"${CMAKE_BINARY_DIR}/src/GameSrc/Headers/shockolate_version.h" )
 
 # Configuration done. Print features
 feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,15 +113,31 @@ if(NOT WIN32)
   endif(ALSA_FOUND)
 endif(NOT WIN32)
 
+# Generate version based on project version
+set(PROJECT_REVERSION_STRING "")
+find_package(Git)
+if(GIT_FOUND)
+	message(STATUS "git found: ${GIT_EXECUTABLE}")
+	execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE git_describe_out
+		ERROR_VARIABLE git_describe_error
+		RESULT_VARIABLE git_describe_result
+		)
+	string(REGEX MATCH "[a-z|0-9|.]*-[0-9]*-g([a-z|0-9]*)([-|a-z]*)" git_commit "${git_describe_out}")
+	set(git_commit ${CMAKE_MATCH_1})
+	set(git_dirty ${CMAKE_MATCH_2})
+	set(PROJECT_REVERSION_STRING "-g${git_commit}${git_dirty}")
+endif(GIT_FOUND)
+
+message(STATUS "Version is ${PROJECT_VERSION}${PROJECT_REVERSION_STRING}")
+configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/version.h.in" "${CMAKE_BINARY_DIR}/src/GameSrc/Headers/version.h" )
+
 # Configuration done. Print features
 feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")
 feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
 
 # Sources configuration
-
-# Generate version based on project version
-configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/version.h.in" "${CMAKE_BINARY_DIR}/src/GameSrc/Headers/version.h" )
-
 add_subdirectory(src/Libraries/)
 
 set(MAC_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_feature_info(ENABLE_SOUND ENABLE_SOUND "Enable sound support (requires SDL2_
 
 set(ENABLE_FLUIDSYNTH "BUNDLED" CACHE STRING "Enable FluidSynth MIDI support (ON/BUNDLED/OFF, default BUNDLED)")
 set_property(CACHE ENABLE_FLUIDSYNTH PROPERTY STRINGS "ON" "BUNDLED" "OFF")
-add_feature_info(ENABLE_FLUIDSYNTH ENABLE_FLUIDSYNTH "Enable sound support")
+add_feature_info(ENABLE_FLUIDSYNTH ENABLE_FLUIDSYNTH "Enable FluidSynth MIDI support")
 
 # HAAAAX!!
 add_definitions(-DSVGA_SUPPORT)
@@ -117,7 +117,6 @@ endif(NOT WIN32)
 set(PROJECT_REVERSION_STRING "")
 find_package(Git)
 if(GIT_FOUND)
-	message(STATUS "git found: ${GIT_EXECUTABLE}")
 	execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		OUTPUT_VARIABLE git_describe_out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
 
 # Sources configuration
 
+# Generate version based on project version
+configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/version.h.in" "${CMAKE_BINARY_DIR}/src/GameSrc/Headers/version.h" )
+
 add_subdirectory(src/Libraries/)
 
 set(MAC_SRC
@@ -275,6 +278,7 @@ include_directories(
 	src/GameSrc/Headers
 	src/MacSrc
 	src/MusicSrc
+	${CMAKE_BINARY_DIR}/src/GameSrc/Headers
 )
 
 if(ENABLE_EXAMPLES)

--- a/src/GameSrc/Headers/shockolate_version.h.in
+++ b/src/GameSrc/Headers/shockolate_version.h.in
@@ -1,6 +1,6 @@
 /*
 
-Copyright (C) 2015-2018 Night Dive Studios, LLC.
+Copyright (C) 2019 Shockolate Project
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,17 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // This is autgenerated CMake file, don't edit it manually!
 
-#define SS_VERSION_NUM "1.6"
-#define SS_GREEK_LETTER "F" // CD is in Final!
-
-// C is for cookie, it's good enough for me.
-
-#ifdef SVGA_SUPPORT
-#define SS_FLAG_LETTER "C" // for CD ship
-#else
-#define SS_FLAG_LETTER "S" // for ship
-#endif                     // SVGA_SUPPORT
-
-#define SYSTEM_SHOCK_VERSION "v" SS_GREEK_LETTER SS_VERSION_NUM SS_FLAG_LETTER
+#ifndef SHOCKOLATE_SRC_GAMESRC_HEADERS_SHOCOLATE_VERSION_H_
+#define SHOCKOLATE_SRC_GAMESRC_HEADERS_SHOCOLATE_VERSION_H_
 
 #define SHOCKOLATE_VERSION "Shockolate @PROJECT_VERSION@@PROJECT_REVERSION_STRING@"
+
+#endif // SHOCKOLATE_SRC_GAMESRC_HEADERS_SHOCOLATE_VERSION_H_

--- a/src/GameSrc/Headers/version.h
+++ b/src/GameSrc/Headers/version.h
@@ -1,0 +1,31 @@
+/*
+
+Copyright (C) 2015-2018 Night Dive Studios, LLC.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#define SS_VERSION_NUM "1.6"
+#define SS_GREEK_LETTER "F" // CD is in Final!
+
+// C is for cookie, it's good enough for me.
+
+#ifdef SVGA_SUPPORT
+#define SS_FLAG_LETTER "C" // for CD ship
+#else
+#define SS_FLAG_LETTER "S" // for ship
+#endif                     // SVGA_SUPPORT
+
+#define SYSTEM_SHOCK_VERSION "v" SS_GREEK_LETTER SS_VERSION_NUM SS_FLAG_LETTER

--- a/src/GameSrc/Headers/version.h.in
+++ b/src/GameSrc/Headers/version.h.in
@@ -16,6 +16,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+
+// This is autgenerated CMake file, don't edit it manually!
+
 #define SS_VERSION_NUM "1.6"
 #define SS_GREEK_LETTER "F" // CD is in Final!
 
@@ -29,4 +32,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SYSTEM_SHOCK_VERSION "v" SS_GREEK_LETTER SS_VERSION_NUM SS_FLAG_LETTER
 
-#define SHOCKOLATE_VERSION "Shockolate 0.6"
+#define SHOCKOLATE_VERSION "Shockolate @PROJECT_VERSION@"

--- a/src/GameSrc/Headers/version.h.in
+++ b/src/GameSrc/Headers/version.h.in
@@ -32,4 +32,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SYSTEM_SHOCK_VERSION "v" SS_GREEK_LETTER SS_VERSION_NUM SS_FLAG_LETTER
 
-#define SHOCKOLATE_VERSION "Shockolate @PROJECT_VERSION@"
+#define SHOCKOLATE_VERSION "Shockolate @PROJECT_VERSION@@PROJECT_REVERSION_STRING@"

--- a/src/GameSrc/init.c
+++ b/src/GameSrc/init.c
@@ -73,7 +73,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "dynmem.h"
 #include "citres.h"
 
-#include "version.h" // for system shock version number
+#include "shockolate_version.h" // for system shock version number
 
 #include "Modding.h"
 #include <SDL.h>

--- a/src/MacSrc/InitMac.c
+++ b/src/MacSrc/InitMac.c
@@ -38,6 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#include "MacTune.h"
 #include <SDL.h>
 
+#include "shockolate_version.h"
 #include "tickcount.h"
 
 //--------------------
@@ -94,7 +95,7 @@ long 				*tmd_ticks;
 //------------------------------------------------------------------------------------
 void InitMac(void)
 {
-	INFO("Starting Shockolate");
+	INFO("Starting %s", SHOCKOLATE_VERSION);
 
 	// Get a random seed
 	gRandSeed = TickCount();

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -60,6 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "physics.h"
 #include "wrapper.h"
 #include "version.h"
+#include "shockolate_version.h"
 
 #include "Modding.h"
 


### PR DESCRIPTION
After building executable will have nice autogenerated version like "Shockolate 0.7.8-g66e2ada" (if project built from git) or simple "Shockolate 0.7.8".

On every major update and release project version in CMakeLists.txt should be incremented. In future this information can be used for autopackaging.