### PR TITLE
Music:  Load the correct midi resources for the music device in use.

### DIFF
--- a/src/MacSrc/SDLSound.c
+++ b/src/MacSrc/SDLSound.c
@@ -1,6 +1,5 @@
-
-#include "adlmidi.h"
 #include "Xmi.h"
+#include "MusicDevice.h"
 
 #ifdef USE_SDL_MIXER
 
@@ -141,38 +140,26 @@ int MacTuneLoadTheme(char* theme_base, int themeID) {
 	#define MAX_KEYS                   10
 	#define NUM_LAYERABLE_SUPERCHUNKS  22
 	#define KEY_BAR_RESOLUTION          2
-	
+
 	extern uchar track_table[NUM_SCORES][SUPERCHUNKS_PER_SCORE];
 	extern uchar transition_table[NUM_TRANSITIONS];
 	extern uchar layering_table[NUM_LAYERS][MAX_KEYS];
 	extern uchar key_table[NUM_LAYERABLE_SUPERCHUNKS][KEY_BAR_RESOLUTION];
-	
+
     StopTheMusic();
 
 	FreeXMI();
-	
+
 	if (strncmp(theme_base, "thm", 3))
 	{
-	  // Try to use sblaster files, fall back to genmidi
-	  sprintf(filename, "res/sound/sblaster/%s.xmi", theme_base);
-	  int readFile = ReadXMI(filename);
-
-	  if(!readFile) {
-	  	sprintf(filename, "res/sound/genmidi/%s.xmi", theme_base);
-	  	ReadXMI(filename);
-	  }
+	  sprintf(filename, "res/sound/%s/%s.xmi", MusicDev->musicType, theme_base);
+	  ReadXMI(filename);
 	}
 	else
 	{
-	  // Try to use sblaster files, fall back to genmidi
-	  sprintf(filename, "res/sound/sblaster/thm%i.xmi", themeID);
-	  int readFile = ReadXMI(filename);
+	  sprintf(filename, "res/sound/%s/thm%i.xmi", MusicDev->musicType, themeID);
+	  ReadXMI(filename);
 
-	  if(!readFile) {
-	  	sprintf(filename, "res/sound/genmidi/thm%i.xmi", themeID);
-	  	ReadXMI(filename);
-	  }
-	
 	  sprintf(filename, "res/sound/thm%i.bin", themeID);
 	  extern FILE *fopen_caseless(const char *path, const char *mode); //see caseless.c
 	  f = fopen_caseless(filename, "rb");

--- a/src/MusicSrc/MusicDevice.c
+++ b/src/MusicSrc/MusicDevice.c
@@ -166,6 +166,7 @@ static MusicDevice *createNullMidiDevice()
     dev->isOpen = 0;
     dev->outputIndex = 0;
     dev->deviceType = Music_None;
+    dev->musicType = MUSICTYPE_SBLASTER;
     return dev;
 }
 
@@ -341,6 +342,7 @@ static MusicDevice *createAdlMidiDevice()
     adev->dev.isOpen = 0;
     adev->dev.outputIndex = 0;
     adev->dev.deviceType = Music_AdlMidi;
+    adev->dev.musicType = MUSICTYPE_SBLASTER;
     return &adev->dev;
 }
 
@@ -993,6 +995,7 @@ static MusicDevice *createNativeMidiDevice()
     ndev->alsaOutputId = 0;
     ndev->alsaOutputPort = 0;
 #endif
+    ndev->dev.musicType = MUSICTYPE_GENMIDI;
     return &(ndev->dev);
 }
 
@@ -1281,6 +1284,7 @@ static MusicDevice *createFluidSynthDevice()
     fdev->dev.isOpen = 0;
     fdev->dev.outputIndex = 0;
     fdev->dev.deviceType = Music_FluidSynth;
+    fdev->dev.musicType = MUSICTYPE_GENMIDI;
     return &(fdev->dev);
 }
 #endif // USE_FLUIDSYNTH

--- a/src/MusicSrc/MusicDevice.h
+++ b/src/MusicSrc/MusicDevice.h
@@ -34,9 +34,13 @@ struct MusicDevice
     void (*sendPitchBendML)(MusicDevice *dev, int channel, int msb, int lsb);
     unsigned int (*getOutputCount)(MusicDevice *dev);
     void (*getOutputName)(MusicDevice *dev, const unsigned int outputIndex, char *buffer, const unsigned int bufferSize);
-    unsigned short isOpen;      // 1 if device open, 0 if closed
+    unsigned short isOpen;    // 1 if device open, 0 if closed
     unsigned int outputIndex; // index of currently opened output
-    MusicType deviceType;       // type of device
+    MusicType deviceType;     // type of device
+    char *musicType;          // "sblaster" or "genmidi"
 };
+
+#define MUSICTYPE_SBLASTER "sblaster"
+#define MUSICTYPE_GENMIDI  "genmidi"
 
 MusicDevice *CreateMusicDevice(MusicType type);


### PR DESCRIPTION
 - sblaster for ADLMIDI
 - genmidi for FluidSynth and external

The weakness of this patch is that switching the music device in game won't
trigger a reload of the music resources.

(Personally I think the genmidi resources sound a lot better than the sblaster resources on real GM devices, if only because much greater polyphony is available)