### PR TITLE
raise window on resize

### DIFF
--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -107,6 +107,8 @@ void ChangeScreenSize(int width, int height) {
     SDL_SetWindowSize(window, width, height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
+    SDL_RaiseWindow(window); //we could lose focus above
+
     SDL_RenderSetLogicalSize(renderer, width, height);
 
     SetupOffscreenBitmaps(width, height);


### PR DESCRIPTION
when shockolate starts, window is set to a certain small size, raised,
but then is immediately resized to its size specified in the options
this often causes the window to lose focus