### PR TITLE
check input instead of mouse focus

### DIFF
--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -351,7 +351,7 @@ void SetMouseXY(int mx, int my) {
     }
 
     bool inside = (mx >= x && mx < x + w && my >= y && my < y + h);
-    bool focus = (SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_FOCUS);
+    bool focus = (SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS); //checking mouse focus isn't what we want here
 
     if (!inside && focus) {
         if (mx < x)


### PR DESCRIPTION
mouse pointer visibility outside game window should occur when
game is paused (by hitting esc), in a menu (such as the main or options menus),
or when window does not have input focus

by using input focus, instead of mouse focus, this works as expected
and prevents distracting pointer visibility