### PR TITLE
keep window focus on resize

### DIFF
--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -87,27 +87,33 @@ void mac_set_mode(void) {
 }
 
 void ChangeScreenSize(int width, int height) {
-    extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
-    if (gScreenWide == width && gScreenHigh == height)
-        return;
-
     extern SDL_Renderer *renderer;
     extern SDL_Window *window;
-
     extern char *gScreenAddress;
     extern long gScreenRowbytes;
+    extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;
+    extern bool fullscreenActive;
+
+    if (gScreenWide == width && gScreenHigh == height)
+    {
+        SDL_ShowWindow(window); //it might be hidden on startup, so show it for the first time
+        return;
+    }
 
     INFO("ChangeScreenSize");
 
+    SDL_HideWindow(window); //when game starts up, window will already be hidden
+
     SDL_RenderClear(renderer);
 
-    extern bool fullscreenActive;
     SDL_SetWindowFullscreen(window, fullscreenActive ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 
     SDL_SetWindowSize(window, width, height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
     SDL_RenderSetLogicalSize(renderer, width, height);
+
+    SDL_ShowWindow(window); //if game is just starting up, show it for the first time
 
     SetupOffscreenBitmaps(width, height);
 

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -251,10 +251,11 @@ void InitSDL()
 
 	sprintf(window_title, "System Shock - %s", SHOCKOLATE_VERSION);
 
+	//keep window hidden for now; it will be shown later during resize (see MacDev.c)
+	//raising window and showing cursor will be done later
 	window = SDL_CreateWindow(
 		window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-		grd_cap->w, grd_cap->h, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
-
+		grd_cap->w, grd_cap->h, SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
 
 	// Create the palette
 
@@ -267,11 +268,7 @@ void InitSDL()
 
 	gr_alloc_ipal();
 
-	SDL_ShowCursor(SDL_DISABLE);
-
 	atexit(SDL_Quit);
-
-	SDL_RaiseWindow(window);
 
 	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC);
 	SDL_RenderSetLogicalSize(renderer, grd_cap->w, grd_cap->h);


### PR DESCRIPTION
when game starts up, there is an immediate resize that interferes with
input focus, so keep the window hidden until everything's ready