### PR TITLE
Require preinstalled CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Find a list of [downloadable packages](https://github.com/Interrupt/systemshock/
 
 ## From source code
 
+Prerequisites: 
+- [CMake](https://cmake.org/download/) installed
+
 Step 1. Build the dependencies:
 * Windows: `build_win32.sh` or `build_win64.sh` (Git Bash and MinGW recommended)
 * Linux/Mac: `build_deps.sh` or the CI build scripts in `osx-linux`

--- a/build_win32.sh
+++ b/build_win32.sh
@@ -113,7 +113,6 @@ mv build_ext/fluidsynth-lite/*.sf2 ./res
 if [[ -z "${APPVEYOR}" ]]; then
 	echo "Normal build"
 	echo "@echo off
-	set PATH=%PATH%;${CMAKE_ROOT}
 	cmake -G \"${CMAKE_target}\" .
 	mingw32-make systemshock" >build.bat
 else

--- a/build_win32.sh
+++ b/build_win32.sh
@@ -4,9 +4,6 @@ set -e
 SDL_version=2.0.10
 SDL2_mixer_version=2.0.4
 GLEW_version=2.1.0
-CMAKE_version=3.11.3
-#CMAKE_architecture=win64-x64
-CMAKE_architecture=win32-x86
 CMAKE_target=Unix\ Makefiles
 
 # Removing the mwindows linker option lets us get console output
@@ -59,20 +56,12 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	${CMAKE_ROOT}/cmake -G "${CMAKE_target}" .
-	${CMAKE_ROOT}/cmake --build .
+	cmake -G "${CMAKE_target}" .
+	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
 	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
 	set -e
-	popd
-}
-
-function get_cmake {
-	curl -O https://cmake.org/files/v3.11/cmake-${CMAKE_version}-${CMAKE_architecture}.zip
-	unzip cmake-${CMAKE_version}-${CMAKE_architecture}.zip
-	pushd cmake-${CMAKE_version}-${CMAKE_architecture}/bin
-	CMAKE_ROOT=`pwd -W`/
 	popd
 }
 
@@ -81,6 +70,13 @@ function get_cmake {
 if [ -d ./build_ext/ ]; then
 	echo A directory named build_ext already exists.
 	echo Please remove it if you want to recompile.
+	exit
+fi
+
+if ! [ -x "$(command -v cmake)" ]; then
+	echo CMake is needed to install Shockolate. 
+	echo Please download CMake from https://cmake.org/download/,
+	echo install it and try again in a new Git Bash window.
 	exit
 fi
 
@@ -97,16 +93,10 @@ mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
 
-if ! [ -x "$(command -v cmake)" ]; then
-	echo "Getting CMake"
-	get_cmake
-fi
-
-build_fluidsynth
-
 build_sdl
 build_sdl_mixer
 build_glew
+build_fluidsynth
 
 
 # Back to the root directory, copy required DLL files for the executable

--- a/build_win64.sh
+++ b/build_win64.sh
@@ -4,9 +4,6 @@ set -e
 SDL_version=2.0.10
 SDL2_mixer_version=2.0.4
 GLEW_version=2.1.0
-CMAKE_version=3.11.3
-CMAKE_architecture=win64-x64
-#CMAKE_architecture=win32-x86
 CMAKE_target=Unix\ Makefiles
 
 # Removing the mwindows linker option lets us get console output
@@ -41,20 +38,12 @@ function build_fluidsynth {
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it
 	set +e
-	${CMAKE_ROOT}/cmake -G "${CMAKE_target}" .
-	${CMAKE_ROOT}/cmake --build .
+	cmake -G "${CMAKE_target}" .
+	cmake --build .
 
 	# download a soundfont that's close to the Windows default everyone knows
 	curl -o music.sf2 http://rancid.kapsi.fi/windows.sf2
 	set -e
-	popd
-}
-
-function get_cmake {
-	curl -O https://cmake.org/files/v3.11/cmake-${CMAKE_version}-${CMAKE_architecture}.zip
-	unzip cmake-${CMAKE_version}-${CMAKE_architecture}.zip
-	pushd cmake-${CMAKE_version}-${CMAKE_architecture}/bin
-	CMAKE_ROOT=`pwd -W`/
 	popd
 }
 
@@ -63,6 +52,13 @@ function get_cmake {
 if [ -d ./build_ext/ ]; then
 	echo A directory named build_ext already exists.
 	echo Please remove it if you want to recompile.
+	exit
+fi
+
+if ! [ -x "$(command -v cmake)" ]; then
+	echo CMake is needed to install Shockolate. 
+	echo Please download CMake from https://cmake.org/download/,
+	echo install it and try again in a new Git Bash window.
 	exit
 fi
 
@@ -78,11 +74,6 @@ fi
 mkdir ./build_ext/
 cd ./build_ext/
 install_dir=`pwd -W`
-
-if ! [ -x "$(command -v cmake)" ]; then
-	echo "Getting CMake"
-	get_cmake
-fi
 
 
 build_sdl

--- a/build_win64.sh
+++ b/build_win64.sh
@@ -96,7 +96,6 @@ mv build_ext/fluidsynth-lite/*.sf2 ./res
 if [[ -z "${APPVEYOR}" ]]; then
 	echo "Normal build"
 	echo "@echo off
-	set PATH=%PATH%;${CMAKE_ROOT}
 	cmake -G \"${CMAKE_target}\" .
 	mingw32-make systemshock" >build.bat
 else


### PR DESCRIPTION
The Windows build scripts currently try to download CMake if it hasn't already been installed. This is kind of a bad idea because the actual game compilation still requires CMake on the PATH -- so I removed the CMake downloading function, and added a check for a CMake binary that errors out if it's not found.

Similar stuff should probably be added to the other dependency build scripts.