### PR TITLE
Fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ before_deploy:
   - cp osx-linux/run_$TRAVIS_OS_NAME.sh shockolate/run.sh
   - cp -r shaders shockolate/
   - cp -r res shockolate/
-  - tar zcfv $PACKAGE_NAME shockolate
-  - rm -r shockolate
+  - tar zcfv $PACKAGE_NAME shockolate/
+  - rm -r shockolate/
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: c
 notifications:
   email: false
 
-env:
-  - PACKAGE_NAME="shockolate-$TRAVIS_OS_NAME-${BITS}bit.tgz"
-
 matrix:
   include:
     - os: linux
@@ -66,8 +63,9 @@ before_deploy:
   - cp osx-linux/run_$TRAVIS_OS_NAME.sh shockolate/run.sh
   - cp -r shaders shockolate/
   - cp -r res shockolate/
-  - tar zcfv $PACKAGE_NAME shockolate/
-  - rm -r shockolate/
+  - export PACKAGE_NAME="shockolate-$TRAVIS_OS_NAME-${BITS}bit.tgz"
+  - tar zcfv $PACKAGE_NAME shockolate
+  - rm -r shockolate
 
 deploy:
   provider: releases


### PR DESCRIPTION
The existence of a build matrix broke the `env` setup, causing the `tar` command to fail and breaking release deployments. This fixes it in a bit of a hacky way, but I couldn't find a nicer way to do it with a quick look at Travis docs.

More info: 
There's an `env.global` setting, which is what we'd need to set, but we can't refer to variables set inside the build matrix (ie. `BITS`) in the global setting. So we have to find a way to set the global variable _after_ setting the build-specific ones. And this is the nicest way I found. 