### PR TITLE
Cmake updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 addons:
   homebrew:
     packages:
-      - fluid-synth
       - sdl2
       - sdl2_mixer
     update: true
@@ -43,13 +42,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository -y ppa:savoury1/multimedia ; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get -q update ; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && "$ARCH" = "i386" ]]; then sudo apt-get install -y gcc-multilib g++-multilib libc6-dev-i386 ; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -y cmake libglu1-mesa-dev:${ARCH} libgl1-mesa-dev:${ARCH} libfluidsynth-dev:${ARCH} libsdl2-dev:${ARCH} libsdl2-mixer-dev:${ARCH} ; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -y cmake libglu1-mesa-dev:${ARCH} libgl1-mesa-dev:${ARCH} libsdl2-dev:${ARCH} libsdl2-mixer-dev:${ARCH} ; fi
 
 before_script:
   - echo ARCH=${ARCH} CC=${CC}
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=LITE -DENABLE_OPENGL=ON ..
   - cmake --build . -j 2
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,61 +3,57 @@ language: c
 notifications:
   email: false
 
-matrix:
+os:
+  - linux
+  - osx
+
+dist: bionic
+
+env:
+  global:
+    - BITS=64
+    - ARCH=amd64
+
+addons:
+  homebrew:
+    packages:
+      - fluid-synth
+      - sdl2
+      - sdl2_mixer
+
+compiler:
+  - clang
+  - gcc
+
+jobs:
   include:
     - os: linux
-      dist: bionic
-      sudo: required
+      compiler:
+        - gcc
       env:
-        - SDL2_LIB=BUNDLED
-        - SDL2_MIXER_LIB=BUNDLED
-        - FLUIDSYNTH_LIB=BUNDLED
-        - BITS=64
-      addons:
-        apt:
-          packages:
-            - cmake-data cmake libglu1-mesa-dev libgl1-mesa-dev # libfluidsynth-dev libsdl2-dev libsdl2-mixer-dev
-      compiler: gcc
-    - os: linux
-      dist: trusty
-      sudo: required
-      env:
-        - SDL2_LIB=BUNDLED
-        - SDL2_MIXER_LIB=BUNDLED
-        - FLUIDSYNTH_LIB=BUNDLED
-        - CMAKE_LIBRARY_PATH=/usr/lib/i386-linux-gnu
+        - ARCH="i386"
         - BITS=32
-      before_script:
-        - cp ./CMakeLists.32bit.txt ./CMakeLists.txt
-      addons:
-        apt:
-          packages:
-            - cmake-data cmake libx32gcc-4.8-dev libc6-dev-i386 gcc-multilib g++-multilib libglu1-mesa-dev:i386 libgl1-mesa-dev:i386
-      compiler: gcc
-    - os: osx
-      compiler: clang
-      env:
-        - SDL2_LIB=BUNDLED
-        - SDL2_MIXER_LIB=BUNDLED
-        - FLUIDSYNTH_LIB=OFF # Bundled lib failed to compile
-        - BITS=64
-    - os: osx
-      compiler: gcc
-      env:
-        - SDL2_LIB=BUNDLED
-        - SDL2_MIXER_LIB=BUNDLED
-        - FLUIDSYNTH_LIB=OFF # Bundled lib failed to compile
-        - BITS=64
+        - CFLAGS="-m32"
+        - CXXFLAGS="-m32"
+        - CMAKE_PREFIX_PATH="/usr"
+        - CMAKE_LIBRARY_ARCHITECTURE="i386-linux-gnu"
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository -y ppa:savoury1/multimedia ; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get -q update ; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && "$ARCH" = "i386" ]]; then sudo apt-get install -y gcc-multilib g++-multilib libc6-dev-i386 ; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -y cmake libglu1-mesa-dev:${ARCH} libgl1-mesa-dev:${ARCH} libfluidsynth-dev:${ARCH} libsdl2-dev:${ARCH} libsdl2-mixer-dev:${ARCH} ; fi
+
+before_script:
+  - echo ARCH=${ARCH} CC=${CC}
 script:
-  - chmod a+rx ./osx-linux/*.sh
-  - sudo TRAVIS=$TRAVIS ./osx-linux/install_${BITS}bit_sdl.sh
-  - cmake -DENABLE_SDL2=${SDL2_LIB} -DENABLE_SOUND=${SDL2_MIXER_LIB} -DENABLE_FLUIDSYNTH=${FLUIDSYNTH_LIB} .
-  - make -j2 systemshock
+  - mkdir build && cd build
+  - cmake -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON ..
+  - cmake --build . -j 2
 
 before_deploy:
   - mkdir -p shockolate
-  - cp systemshock shockolate
+  - cp build/systemshock shockolate
   - cp osx-linux/install_${BITS}bit_sdl.sh shockolate/install_sdl.sh
   - cp osx-linux/readme_osx_linux.md shockolate
   - cp osx-linux/run_$TRAVIS_OS_NAME.sh shockolate/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - fluid-synth
       - sdl2
       - sdl2_mixer
+    update: true
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - echo ARCH=${ARCH} CC=${CC}
 script:
   - mkdir build && cd build
-  - cmake -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON ..
   - cmake --build . -j 2
 
 before_deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(ENABLE_SOUND "Enable sound support (requires SDL2_mixer)" ON)
 # Tristate Fluidsynth
 set(ENABLE_FLUIDSYNTH "LITE" CACHE STRING "Enable FluidSynth MIDI support (ON/LITE/OFF, default LITE)")
 set_property(CACHE ENABLE_FLUIDSYNTH PROPERTY STRINGS "ON" "LITE" "OFF")
+option(ENABLE_WIN_CONSOLE "Enable debug console in Windows" ON)
 
 # HAAAAX!!
 add_definitions(-DSVGA_SUPPORT)
@@ -378,7 +379,10 @@ add_library(GAME_LIB ${GAME_SRC})
 
 # MINGW additional linker options
 if(MINGW)
-	set(WINDOWS_LIBRARIES mingw32 -mwindows winmm)
+	set(WINDOWS_LIBRARIES mingw32 winmm)
+	if(ENABLE_WIN_CONSOLE)
+		list(APPEND ENABLE_WIN_CONSOLE -mwindows)
+	endif(ENABLE_WIN_CONSOLE)
 endif(MINGW)
 
 target_link_libraries(systemshock
@@ -397,7 +401,6 @@ target_link_libraries(systemshock
 	INPUT_LIB
 	PALETTE_LIB
 	RES_LIB
-#	SND_LIB
 	VOX_LIB
 	EDMS_LIB
 	FIXPP_LIB

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,49 +35,53 @@ add_compile_options(-fsigned-char -fno-strict-aliasing)
 if(ENABLE_OPENGL)
 	find_package(OpenGL REQUIRED)
 	add_definitions(-DUSE_OPENGL)
+	list(APPEND SHOCK_INCLUDES ${OPENGL_INCLUDE_DIRS})
+	list(APPEND SHOCK_LIBRARIES ${OPENGL_LIBRARIES})
 	if(MINGW)
 		set(GLEW_USE_STATIC_LIBS 1)
 		find_package(GLEW REQUIRED)
-		list(APPEND OPENGL_INCLUDE_DIRS ${GLEW_INCLUDE_DIRS})
-		list(APPEND OPENGL_LIBRARIES GLEW::GLEW)
+		list(APPEND SHOCK_INCLUDES ${GLEW_INCLUDE_DIRS})
+		list(APPEND SHOCK_LIBRARIES GLEW::GLEW)
 	endif(MINGW)
 endif(ENABLE_OPENGL)
 
-if(ENABLE_SDL2 MATCHES "ON")
-	find_package(SDL2 REQUIRED)
-endif(ENABLE_SDL2 MATCHES "ON")
+find_package(SDL2 REQUIRED)
+list(APPEND SHOCK_INCLUDES ${SDL2_INCLUDE_DIRS})
+list(APPEND SHOCK_LIBRARIES ${SDL2_LIBRARIES})
 
-if(ENABLE_SOUND MATCHES "ON")
+if(ENABLE_SOUND)
 	# FIXME applies only for *nix systems
 	find_package(PkgConfig)
 	pkg_check_modules(SDL2_MIXER REQUIRED SDL2_mixer>=2.0.4)
-	add_definitions(-DUSE_SDL_MIXER=1)
-endif(ENABLE_SOUND MATCHES "ON")
+	add_definitions(-DUSE_SDL_MIXER)
+	list(APPEND SHOCK_INCLUDES ${SDL2_MIXER_INCLUDE_DIRS})
+	list(APPEND SHOCK_LIBRARIES ${SDL2_MIXER_LIBRARIES})
+endif(ENABLE_SOUND)
 
 if(ENABLE_FLUIDSYNTH MATCHES "ON")
 	find_package(PkgConfig)
 	pkg_check_modules(FLUIDSYNTH REQUIRED fluidsynth)
-	add_definitions("-DUSE_FLUIDSYNTH=1")
+	add_definitions("-DUSE_FLUIDSYNTH")
+	list(APPEND SHOCK_INCLUDES ${FLUIDSYNTH_INCLUDE_DIRS})
+	list(APPEND SHOCK_LIBRARIES ${FLUIDSYNTH_LIBRARIES})
 endif(ENABLE_FLUIDSYNTH MATCHES "ON")
 
-include_directories(
-	${SDL2_INCLUDE_DIRS}
-	${SDL2_MIXER_INCLUDE_DIRS}
-	${FLUIDSYNTH_INCLUDE_DIRS}
-	${OPENGL_INCLUDE_DIRS}
-)
-
 if(NOT WIN32)
-  # Find ALSA for Linux native MIDI
-  # NOTE: this seems to require having 64-bit dev packages installed when building
-  #  on 64-bit OS, even when building a 32-bit binary
-  find_package(ALSA)
-  if(ALSA_FOUND)
-      message(STATUS "ALSA found")
-      include_directories(${ALSA_INCLUDE_DIRS})
-      add_definitions(-DUSE_ALSA=1)
-  endif(ALSA_FOUND)
+	# Find ALSA for Linux native MIDI
+	# NOTE: this seems to require having 64-bit dev packages installed when building
+	#  on 64-bit OS, even when building a 32-bit binary
+	find_package(ALSA)
+	if(ALSA_FOUND)
+		message(STATUS "ALSA found")
+		list(APPEND SHOCK_INCLUDES ${ALSA_INCLUDE_DIRS})
+		list(APPEND SHOCK_LIBRARIES ${ALSA_LIBRARIES})
+		add_definitions(-DUSE_ALSA)
+	endif(ALSA_FOUND)
 endif(NOT WIN32)
+
+include_directories(
+	${SHOCK_INCLUDES}
+)
 
 # Generate version based on project version
 set(PROJECT_REVERSION_STRING "")
@@ -352,6 +356,7 @@ endif(MINGW)
 
 target_link_libraries(systemshock
 	${WINDOWS_LIBRARIES} # Set it before any linker options! Beware WinMain@16 error!!
+	${SHOCK_LIBRARIES}
 	GAME_LIB
 	UI_LIB
 	2D_LIB
@@ -370,11 +375,6 @@ target_link_libraries(systemshock
 	EDMS_LIB
 	FIXPP_LIB
 	ADLMIDI_LIB
-	${SDL2_LIBRARIES}
-	${SDL2_MIXER_LIBRARIES}
-	${FLUIDSYNTH_LIBRARIES}
-	${OPENGL_LIBRARIES}
-	${ALSA_LIBRARIES}
 )
 
 # Turn on address sanitizing if wanted

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,25 +50,17 @@ add_compile_options(-fsigned-char -fno-strict-aliasing)
 if(ENABLE_OPENGL)
 	find_package(OpenGL REQUIRED)
 	add_definitions(-DUSE_OPENGL)
-	if(WIN32)
-		list(APPEND OPENGL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/build_ext/built_glew/include)
-		list(APPEND OPENGL_LIBRARIES ${CMAKE_SOURCE_DIR}/build_ext/built_glew/lib/libglew32.dll.a winmm)
-	endif(WIN32)
+	if(MINGW)
+		set(GLEW_USE_STATIC_LIBS 1)
+		find_package(GLEW REQUIRED)
+		list(APPEND OPENGL_INCLUDE_DIRS ${GLEW_INCLUDE_DIRS})
+		list(APPEND OPENGL_LIBRARIES GLEW::GLEW)
+	endif(MINGW)
 endif(ENABLE_OPENGL)
 
 if(ENABLE_SDL2 MATCHES "ON")
 	find_package(SDL2 REQUIRED)
-	if(SDL2_FOUND)
-		message(STATUS "SDL2 found: ${SDL2_INCLUDE_DIRS} ${SDL2_LIBRARIES}")
-	endif(SDL2_FOUND)
 endif(ENABLE_SDL2 MATCHES "ON")
-if(ENABLE_SDL2 MATCHES "BUNDLED")
-	set(SDL2_DIR ${CMAKE_SOURCE_DIR}/build_ext/built_sdl)
-	find_library(SDL2_LIBRARY SDL2 PATHS ${SDL2_DIR}/lib NO_DEFAULT_PATH)
-	find_library(SDL2MAIN_LIBRARY SDL2main PATHS ${SDL2_DIR}/lib NO_DEFAULT_PATH)
-	set(SDL2_INCLUDE_DIRS ${SDL2_DIR}/include/SDL2)
-	set(SDL2_LIBRARIES "${SDL2MAIN_LIBRARY};${SDL2_LIBRARY}")
-endif(ENABLE_SDL2 MATCHES "BUNDLED")
 
 if(ENABLE_SOUND MATCHES "ON")
 	# FIXME applies only for *nix systems
@@ -76,25 +68,12 @@ if(ENABLE_SOUND MATCHES "ON")
 	pkg_check_modules(SDL2_MIXER REQUIRED SDL2_mixer>=2.0.4)
 	add_definitions(-DUSE_SDL_MIXER=1)
 endif(ENABLE_SOUND MATCHES "ON")
-if(ENABLE_SOUND MATCHES "BUNDLED")
-	set(SDL2_MIXER_DIR ${CMAKE_SOURCE_DIR}/build_ext/built_sdl_mixer)
-	set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_DIR}/include/SDL2)
-	find_library(SDL2_MIXER_LIBRARY SDL2_mixer PATHS ${SDL2_MIXER_DIR}/lib)
-	set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
-	add_definitions(-DUSE_SDL_MIXER=1)
-endif(ENABLE_SOUND MATCHES "BUNDLED")
 
 if(ENABLE_FLUIDSYNTH MATCHES "ON")
 	find_package(PkgConfig)
 	pkg_check_modules(FLUIDSYNTH REQUIRED fluidsynth)
 	add_definitions("-DUSE_FLUIDSYNTH=1")
 endif(ENABLE_FLUIDSYNTH MATCHES "ON")
-if(ENABLE_FLUIDSYNTH MATCHES "BUNDLED")
-        find_library(FLUIDSYNTH_LIBRARY fluidsynth PATHS ${CMAKE_SOURCE_DIR}/build_ext/fluidsynth-lite/src)
-	set(FLUIDSYNTH_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/build_ext/fluidsynth-lite/include)
-	set(FLUIDSYNTH_LIBRARIES ${FLUIDSYNTH_LIBRARY})
-	add_definitions("-DUSE_FLUIDSYNTH=1")
-endif(ENABLE_FLUIDSYNTH MATCHES "BUNDLED")
 
 include_directories(
 	${SDL2_INCLUDE_DIRS}
@@ -105,7 +84,7 @@ include_directories(
 
 if(NOT WIN32)
   # Find ALSA for Linux native MIDI
-  # NOTE: this seems to require having 64-bit dev pacakges installed when building
+  # NOTE: this seems to require having 64-bit dev packages installed when building
   #  on 64-bit OS, even when building a 32-bit binary
   find_package(ALSA)
   if(ALSA_FOUND)
@@ -387,7 +366,7 @@ add_library(GAME_LIB ${GAME_SRC})
 
 # MINGW additional linker options
 if(MINGW)
-	set(WINDOWS_LIBRARIES "mingw32 -mwindows")
+	set(WINDOWS_LIBRARIES mingw32 -mwindows winmm)
 endif(MINGW)
 
 target_link_libraries(systemshock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.11)
 
 project(shockolate VERSION 0.7.8)
 
@@ -25,7 +25,9 @@ option(ENABLE_EXAMPLES "Enable example applications" OFF)
 option(ENABLE_DEBUG_BLIT "Enable debugging blitter" OFF)
 option(ENABLE_OPENGL "Enable OpenGL support" ON)
 option(ENABLE_SOUND "Enable sound support (requires SDL2_mixer)" ON)
-option(ENABLE_FLUIDSYNTH "Enable FluidSynth MIDI support" ON)
+# Tristate Fluidsynth
+set(ENABLE_FLUIDSYNTH "LITE" CACHE STRING "Enable FluidSynth MIDI support (ON/LITE/OFF, default LITE)")
+set_property(CACHE ENABLE_FLUIDSYNTH PROPERTY STRINGS "ON" "LITE" "OFF")
 
 # HAAAAX!!
 add_definitions(-DSVGA_SUPPORT)
@@ -63,13 +65,35 @@ if(ENABLE_SOUND)
 	list(APPEND SHOCK_LIBRARIES ${SDL2_MIXER_LIBRARIES})
 endif(ENABLE_SOUND)
 
-if(ENABLE_FLUIDSYNTH)
+if(ENABLE_FLUIDSYNTH STREQUAL "LITE")
+	include(FetchContent)
+	FetchContent_Declare(
+		fluidsynth-lite
+		# For time being https://github.com/Doom64/fluidsynth-lite/pull/10
+		# https://github.com/Doom64/fluidsynth-lite
+		GIT_REPOSITORY https://github.com/winterheart/fluidsynth-lite.git
+		GIT_SHALLOW	ON
+		GIT_TAG	a414e3055a652b5c8bb34b6e5b43e537468ccde6 # 26.01.2020
+	)
+	FetchContent_GetProperties(fluidsynth-lite)
+	if(NOT fluidsynth-lite_POPULATED)
+		message(STATUS "Populating fluidsynth-lite...")
+		FetchContent_Populate(fluidsynth-lite)
+		add_subdirectory(${fluidsynth-lite_SOURCE_DIR} ${fluidsynth-lite_BINARY_DIR})
+		set_property(TARGET libfluidsynth PROPERTY C_STANDARD 11)
+		message(STATUS "Done.")
+	endif()
+	include_directories(BEFORE SYSTEM ${fluidsynth-lite_SOURCE_DIR}/include ${fluidsynth-lite_BINARY_DIR}/include)
+	add_definitions("-DUSE_FLUIDSYNTH")
+	list(APPEND SHOCK_LIBRARIES libfluidsynth)
+elseif(ENABLE_FLUIDSYNTH)
+	# Use bulky system FluidSynth
 	find_package(PkgConfig)
 	pkg_check_modules(FLUIDSYNTH REQUIRED fluidsynth)
-	add_definitions("-DUSE_FLUIDSYNTH")
 	list(APPEND SHOCK_INCLUDES ${FLUIDSYNTH_INCLUDE_DIRS})
 	list(APPEND SHOCK_LIBRARIES ${FLUIDSYNTH_LIBRARIES})
-endif(ENABLE_FLUIDSYNTH)
+	add_definitions("-DUSE_FLUIDSYNTH")
+endif(ENABLE_FLUIDSYNTH STREQUAL "LITE")
 
 if(NOT WIN32)
 	# Find ALSA for Linux native MIDI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 
 project(shockolate VERSION 0.7.8)
 
+# Prefer new GLVND library interface
+if(POLICY CMP0072)
+	cmake_policy(SET CMP0072 NEW)
+endif()
+
 #set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
 #set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS ON)
 set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -D__STDC_LIMIT_MACROS")
+# FIXME why this is required?
+add_definitions(-D__STDC_LIMIT_MACROS)
 
 option(ENABLE_EXAMPLES "Enable example applications" OFF)
 add_feature_info(ENABLE_EXAMPLES ENABLE_EXAMPLES "Enable example application (can be broken!)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,13 @@ if(ENABLE_SOUND)
 	list(APPEND SHOCK_LIBRARIES ${SDL2_MIXER_LIBRARIES})
 endif(ENABLE_SOUND)
 
-if(ENABLE_FLUIDSYNTH MATCHES "ON")
+if(ENABLE_FLUIDSYNTH)
 	find_package(PkgConfig)
 	pkg_check_modules(FLUIDSYNTH REQUIRED fluidsynth)
 	add_definitions("-DUSE_FLUIDSYNTH")
 	list(APPEND SHOCK_INCLUDES ${FLUIDSYNTH_INCLUDE_DIRS})
 	list(APPEND SHOCK_LIBRARIES ${FLUIDSYNTH_LIBRARIES})
-endif(ENABLE_FLUIDSYNTH MATCHES "ON")
+endif(ENABLE_FLUIDSYNTH)
 
 if(NOT WIN32)
 	# Find ALSA for Linux native MIDI
@@ -87,16 +87,14 @@ include_directories(
 set(PROJECT_REVERSION_STRING "")
 find_package(Git)
 if(GIT_FOUND)
-	execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty
+	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		OUTPUT_VARIABLE git_describe_out
 		ERROR_VARIABLE git_describe_error
 		RESULT_VARIABLE git_describe_result
+		OUTPUT_STRIP_TRAILING_WHITESPACE
 		)
-	string(REGEX MATCH "[a-z|0-9|.]*-[0-9]*-g([a-z|0-9]*)([-|a-z]*)" git_commit "${git_describe_out}")
-	set(git_commit ${CMAKE_MATCH_1})
-	set(git_dirty ${CMAKE_MATCH_2})
-	set(PROJECT_REVERSION_STRING "-g${git_commit}${git_dirty}")
+	set(PROJECT_REVERSION_STRING "-g${git_describe_out}")
 endif(GIT_FOUND)
 
 message(STATUS "Version is ${PROJECT_VERSION}${PROJECT_REVERSION_STRING}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 
 project(shockolate VERSION 0.7.8)
 
-include(FeatureSummary)
-
 #set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
 #set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS ON)
 set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS OFF)
@@ -19,23 +17,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_definitions(-D__STDC_LIMIT_MACROS)
 
 option(ENABLE_EXAMPLES "Enable example applications" OFF)
-add_feature_info(ENABLE_EXAMPLES ENABLE_EXAMPLES "Enable example application (can be broken!)")
 option(ENABLE_DEBUG_BLIT "Enable debugging blitter" OFF)
-add_feature_info(ENABLE_DEBUG_BLIT ENABLE_DEBUG_BLIT "Enable debugging blitter")
 option(ENABLE_OPENGL "Enable OpenGL support" ON)
-add_feature_info(ENABLE_OPENGL ENABLE_OPENGL "Enable OpenGL support")
-
-set(ENABLE_SDL2 "BUNDLED" CACHE STRING "Enable SDL2 (ON/BUNDLED, default BUNDLED)")
-set_property(CACHE ENABLE_SDL2 PROPERTY STRINGS "ON" "BUNDLED")
-add_feature_info(ENABLE_SDL2 ENABLE_SOUND "Enable SDL2 support")
-
-set(ENABLE_SOUND "BUNDLED" CACHE STRING "Enable sound support (requires SDL2_mixer) (ON/BUNDLED/OFF, default BUNDLED)")
-set_property(CACHE ENABLE_SOUND PROPERTY STRINGS "ON" "BUNDLED" "OFF")
-add_feature_info(ENABLE_SOUND ENABLE_SOUND "Enable sound support (requires SDL2_mixer)")
-
-set(ENABLE_FLUIDSYNTH "BUNDLED" CACHE STRING "Enable FluidSynth MIDI support (ON/BUNDLED/OFF, default BUNDLED)")
-set_property(CACHE ENABLE_FLUIDSYNTH PROPERTY STRINGS "ON" "BUNDLED" "OFF")
-add_feature_info(ENABLE_FLUIDSYNTH ENABLE_FLUIDSYNTH "Enable FluidSynth MIDI support")
+option(ENABLE_SOUND "Enable sound support (requires SDL2_mixer)" ON)
+option(ENABLE_FLUIDSYNTH "Enable FluidSynth MIDI support" ON)
 
 # HAAAAX!!
 add_definitions(-DSVGA_SUPPORT)
@@ -113,10 +98,6 @@ endif(GIT_FOUND)
 message(STATUS "Version is ${PROJECT_VERSION}${PROJECT_REVERSION_STRING}")
 configure_file("${CMAKE_SOURCE_DIR}/src/GameSrc/Headers/shockolate_version.h.in"
 	"${CMAKE_BINARY_DIR}/src/GameSrc/Headers/shockolate_version.h" )
-
-# Configuration done. Print features
-feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")
-feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
 
 # Sources configuration
 add_subdirectory(src/Libraries/)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,0 +1,109 @@
+Compiling Shockolate
+====================
+
+Prerequisites: 
+* CMake 3.11
+* SDL2 2.0.9
+* SDL2_mixer 2.0.4 (optional, for sound)
+* FluidSynth (optional)
+
+The following CMake options are supported in the build process:
+* `ENABLE_SOUND` - enable sound support (requires SDL2_mixer)
+* `ENABLE_FLUIDSYNTH` - enable FluidSynth MIDI support (ON/LITE/OFF, default is embedded LITE)
+* `ENABLE_OPENGL` - enable OpenGL support (ON/OFF, default ON)
+
+## Linux
+
+Here example for Ubuntu. Since Shockolate requires decent multimedia libraries, you need add multimedia repository:
+
+```
+sudo add-apt-repository -y ppa:savoury1/multimedia
+sudo apt-get -q update
+sudo apt-get install -y cmake libglu1-mesa-dev libgl1-mesa-dev libsdl2-dev libsdl2-mixer-dev
+```
+
+Now you ready for building.
+
+```
+mkdir systemshock_build
+cd systemshock_build
+cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENGL=ON -DENABLE_SOUND=ON <path to Shockolate sources>
+make -j2
+cp -r <path to Shockolate sources>/shaders . ; mkdir res
+```
+
+After compilation you'll see systemshock executable in `systemshock_build` directory. 
+
+## macOS
+
+Install dependencies via `brew`:
+
+```
+brew install sdl2
+brew install sdl2_mixer
+```
+
+Now you ready for building.
+
+```
+mkdir systemshock_build
+cd systemshock_build
+cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENGL=ON -DENABLE_SOUND=ON <path to Shockolate sources>
+make -j2
+cp -r <path to Shockolate sources>/shaders . ; mkdir res
+```
+
+After compilation you'll see systemshock executable in `systemshock_build` directory. 
+
+## Windows
+
+### 64 bit
+Currently on Windows only MINGW environment is supported. We recommended [MSYS2](https://www.msys2.org/) for that.
+Install MSYS2 and launch MYS2 MinGW 64-bit shell. Install/update required tools:
+
+```
+pacman -Syu --noconfirm     # Close shell and open again
+pacman -Syu --noconfirm     # Second run
+pacman -Sy --noconfirm mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+```  
+
+Install dependencies:
+
+```
+pacman -Sy --noconfirm mingw-w64-x86_64-glew mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer
+```
+
+Now you ready to go. Let's assume that sources resides in `C:\project\systemshock`, then inside MinGW shell it would be
+`/c/project/systemshock`
+
+```
+mkdir systemshock_build
+cd systemshock_build
+cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=/mingw64/bin/pkg-config.exe -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++.exe -DENABLE_SOUND=ON -DENABLE_OPENGL=ON /c/project/systemshock
+cmake --build . -j 2
+cp -r /c/project/systemshock/shader . ; mkdir res
+```
+
+After compilation you'll see systemshock.exe executable in `systemshock_build` directory.
+
+Importunately, currently MinGW build requires some DLLs from environment, there quick hack for it:
+
+```
+cp /mingw64/bin/{libFLAC*,libglib-*,libgmodule-*,libmodplug*,libmpg123*,libportaudio-2,libreadline*,libsndfile*,libogg-*,libtermcap-0,libintl-*,libiconv-*,libopus-0,libpcre-*,libopusfile-0,libvorbis-0,libvorbisenc-2,libvorbisfile-*,libspeex-*}.dll . 
+```
+
+### 32 bit
+
+There no big differences comparing to 64 bit. Launch MYS2 MinGW 32-bit shell and paste these commands:
+
+```
+pacman -Syu --noconfirm     # Close shell and open again
+pacman -Syu --noconfirm     # Second run
+pacman -Sy --noconfirm mingw-w64-i686-toolchain mingw-w64-i686-cmake mingw-w64-i686-ninja
+pacman -Sy --noconfirm mingw-w64-i686-glew mingw-w64-i686-SDL2 mingw-w64-i686-SDL2_mixer
+mkdir systemshock_build
+cd systemshock_build
+cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=/mingw32/bin/pkg-config.exe -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++.exe -DENABLE_SOUND=ON -DENABLE_OPENGL=ON /c/project/systemshock
+cmake --build . -j 2
+cp -r /c/project/systemshock/shader . ; mkdir res
+```

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -8,9 +8,10 @@ Prerequisites:
 * FluidSynth (optional)
 
 The following CMake options are supported in the build process:
-* `ENABLE_SOUND` - enable sound support (requires SDL2_mixer)
+* `ENABLE_SOUND` - enable sound support (requires SDL2_mixer, default is ON)
 * `ENABLE_FLUIDSYNTH` - enable FluidSynth MIDI support (ON/LITE/OFF, default is embedded LITE)
-* `ENABLE_OPENGL` - enable OpenGL support (ON/OFF, default ON)
+* `ENABLE_OPENGL` - enable OpenGL support (ON/OFF, default is ON)
+* `ENABLE_WIN_CONSOLE` - enable debug console for Windows (default is ON)
 
 ## Linux
 

--- a/README.md
+++ b/README.md
@@ -30,29 +30,7 @@ Find a list of [downloadable packages](https://github.com/Interrupt/systemshock/
 
 ## From source code
 
-Prerequisites: 
-- [CMake](https://cmake.org/download/) installed
-
-Step 1. Build the dependencies:
-* Windows: `build_win32.sh` or `build_win64.sh` (Git Bash and MinGW recommended)
-* Linux/Mac: `build_deps.sh` or the CI build scripts in `osx-linux`
-* Other: `build_deps.sh` 
-
-Step 2. Build and run the game itself
-```
-cmake .
-make systemshock
-./systemshock
-```
-
-The following CMake options are supported in the build process:
-* `ENABLE_SDL2` - use system or bundled SDL2 (ON/BUNDLED, default BUNDLED)
-* `ENABLE_SOUND` - enable sound support (requires SDL2_mixer, ON/BUNDLED/OFF, default is BUNDLED)
-* `ENABLE_FLUIDSYNTH` - enable FluidSynth MIDI support (ON/BUNDLED/OFF, default is BUNDLED)
-* `ENABLE_OPENGL` - enable OpenGL support (ON/OFF, default ON)
-
-If you find yourself needing to modify the build script for Shockolate itself, `CMakeLists.txt` is the place to look into.
-
+See [COMPILING.md](COMPILING.md).
 
 Command line parameters
 ============

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,13 +36,13 @@ install:
   # Install/update build tools
   - C:\msys64\usr\bin\bash.exe -lc "pacman -Sy --noconfirm mingw-w64-%ARCH%-toolchain mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-ninja"
   # Install dependencies
-  - C:\msys64\usr\bin\bash.exe -lc "pacman -Sy --noconfirm mingw-w64-%ARCH%-glew mingw-w64-%ARCH%-SDL2 mingw-w64-%ARCH%-fluidsynth mingw-w64-%ARCH%-SDL2_mixer"
+  - C:\msys64\usr\bin\bash.exe -lc "pacman -Sy --noconfirm mingw-w64-%ARCH%-glew mingw-w64-%ARCH%-SDL2 mingw-w64-%ARCH%-SDL2_mixer"
 
 build_script:
   - set PATH=C:\msys64\%MINGW_VERSION%\bin;%PATH%
   - set BUILD_FOLDER=build_%ARCH%
-  - C:\msys64\usr\bin\bash.exe -lc "cd /c/projects/systemshock ; mkdir %BUILD_FOLDER% ; cd %BUILD_FOLDER% ; cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON .. ; cmake --build . -j 2"
-  - C:\msys64\usr\bin\bash.exe -lc "mkdir -p /c/projects/systemshock/res"
+  - C:\msys64\usr\bin\bash.exe -lc "mkdir -p /c/projects/systemshock/%BUILD_FOLDER% /c/projects/systemshock/res"
+  - C:\msys64\usr\bin\bash.exe -lc "cd /c/projects/systemshock/%BUILD_FOLDER% ; cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=LITE -DENABLE_OPENGL=ON .. ; cmake --build . -j 2"
   - curl -o res/music.sf2 -C - http://rancid.kapsi.fi/windows.sf2
 
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,78 +6,71 @@
 # See https://www.appveyor.com/docs/build-environment/ for all the details
 image: Visual Studio 2015
 
-# Tell build_windows.sh that we're building for AppVeyor
-environment:
-  APPVEYOR: TRUE
+init:
+  # Version
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
+        Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
+      } else {
+        Update-AppveyorBuild -Version "dev-$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
+      }
 
-platform:
-  - x64
-  - x86
-  
+# Where our project is
+clone_folder: c:\projects\systemshock
+
+environment:
+  APPVEYOR: true
+  matrix:
+    - MINGW_VERSION: mingw32
+      ARCH: i686
+    - MINGW_VERSION: mingw64
+      ARCH: x86_64
+
+matrix:
+  fast_finish: true
+
+install:
+  # Update environment. Comment by now, not clear what's impact.
+  # - C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
+  # - C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
+  # Install/update build tools
+  - C:\msys64\usr\bin\bash.exe -lc "pacman -Sy --noconfirm mingw-w64-%ARCH%-toolchain mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-ninja"
+  # Install dependencies
+  - C:\msys64\usr\bin\bash.exe -lc "pacman -Sy --noconfirm mingw-w64-%ARCH%-glew mingw-w64-%ARCH%-SDL2 mingw-w64-%ARCH%-fluidsynth mingw-w64-%ARCH%-SDL2_mixer"
+
+build_script:
+  - set PATH=C:\msys64\%MINGW_VERSION%\bin;%PATH%
+  - set BUILD_FOLDER=build_%ARCH%
+  - C:\msys64\usr\bin\bash.exe -lc "cd /c/projects/systemshock ; mkdir %BUILD_FOLDER% ; cd %BUILD_FOLDER% ; cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=/%MINGW_VERSION%/bin/pkg-config.exe -DCMAKE_C_COMPILER=%ARCH%-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=%ARCH%-w64-mingw32-g++.exe -DENABLE_SOUND=ON -DENABLE_FLUIDSYNTH=ON -DENABLE_OPENGL=ON .. ; cmake --build . -j 2"
+  - C:\msys64\usr\bin\bash.exe -lc "mkdir -p /c/projects/systemshock/res"
+  - curl -o res/music.sf2 -C - http://rancid.kapsi.fi/windows.sf2
+
 # Avoid rebuilding external dependencies (ie. SDL and SDL_mixer)
 # Uncache build_ext if external deps change
 cache:
   - res/music.sf2
-  - build_ext  
 
-# Set up environment variable values for 32 and 64 bit builds
-
-for:
-  -
-    matrix:
-      only:
-        - platform: x86
-    before_build:
-      - set BUILD_SCRIPT=build_win32.sh
-      - set ARTIFACT=systemshock-x86.zip
-      - set MINGW_PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
-      - copy CMakeLists.32bit.txt CMakeLists.txt
-  -
-    matrix:
-      only:
-        - platform: x64
-    before_build:
-      - set BUILD_SCRIPT=build_win64.sh
-      - set ARTIFACT=systemshock-x64.zip
-      - set MINGW_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\
-   
-# Actual build script..
-# Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
-#         So we create a symlink to the real Git, remove it from PATH and add our own.
-# Step 2: We need to use our own make.exe to build stuff, so we add that
-# Step 3: Do the actual building
-
-build_script:
-  - mklink /D c:\git "C:\Program Files\Git"
-  - set PATH=%PATH:C:\Program Files (x86)\Git\bin;=%
-  - set PATH=c:\git\usr\bin;%PATH%;%MINGW_PATH%
-  - copy windows\make.exe \git\usr\bin
-  - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
-  - sh %BUILD_SCRIPT%
-  - build.bat
-
-   
 # For now, we don't have any automatic tests to run
-test: off
+test: false
 
 # Once building is done, we gather all the necessary DLL files and build our ZIP file.
 after_build:
-  - copy %MINGW_PATH%\libgcc*.dll .
-  - copy %MINGW_PATH%\libstd*.dll .
-  - copy %MINGW_PATH%\libwinpthread-1.dll .
-  - copy build_ext\built_sdl\bin\SDL*.dll .
-  - copy build_ext\built_sdl_mixer\bin\SDL*.dll .
-  - copy build_ext\built_glew\lib\glew32.dll .
-  - copy build_ext\fluidsynth-lite\src\libfluidsynth.dll .
-  - 7z a %ARTIFACT% systemshock.exe *.dll shaders/ res/
+  # FIXME: Remove after CMake implementation
+  - C:\msys64\usr\bin\bash.exe -lc "cp -R /c/projects/systemshock/res /c/projects/systemshock/shaders /c/projects/systemshock/%BUILD_FOLDER%"
+  # Toolchain deps
+  - C:\msys64\usr\bin\bash.exe -lc "cp /%MINGW_VERSION%/bin/{libgcc*,libstdc++-6,libwinpthread-1}.dll /c/projects/systemshock/%BUILD_FOLDER%"
+  # Direct dependencies
+  - C:\msys64\usr\bin\bash.exe -lc "cp /%MINGW_VERSION%/bin/{SDL2,SDL2_mixer,libfluidsynth-2}.dll /c/projects/systemshock/%BUILD_FOLDER%"
+  # Dependencies of dependencies (seriously, these should be statically linked
+  - C:\msys64\usr\bin\bash.exe -lc "cp /%MINGW_VERSION%/bin/{libFLAC*,libglib-*,libgmodule-*,libmodplug*,libmpg123*,libportaudio-2,libreadline*,libsndfile*}.dll /c/projects/systemshock/%BUILD_FOLDER%"
+  # Ohhhh...
+  - C:\msys64\usr\bin\bash.exe -lc "cp /%MINGW_VERSION%/bin/{libogg-*,libtermcap-0,libintl-*,libiconv-*,libopus-0,libpcre-*,libopusfile-0,libvorbis-0,libvorbisenc-2,libvorbisfile-*,libspeex-*}.dll  /c/projects/systemshock/%BUILD_FOLDER%"
+  - cd C:\projects\systemshock\%BUILD_FOLDER%
+  - 7z a systemshock-%ARCH%.zip systemshock.exe *.dll shaders/ res/
 
 artifacts:
-  - path: systemshock-x86.zip
-    name: Shockolate (32bit)
-  - path: systemshock-x64.zip
-    name: Shockolate (64bit)
-
-version: '0.5.{build}'
+  - path: build_%ARCH%\systemshock-%ARCH%.zip
+    name: Shockolate (%ARCH%)
 
 # Finally, we deploy the ZIP file as a GitHub release
 # FIXME: How do we want to be building releases? Seems like this would be better as a manual process
@@ -87,7 +80,7 @@ deploy:
   - provider: GitHub
     release: $(appveyor_repo_tag_name)
     description: 'Latest release build of Shockolate'
-    artifact: systemshock-x86.zip, systemshock-x64.zip
+    artifact: systemshock-i686.zip, systemshock-x86_64.zip
     auth_token:
       secure: P1kIk8rRxKAYHqDrOWf0Zf5spfR+N86E0lO8VBu99vHtECJgPLn/Z6tBmL9cxPah  
     on:


### PR DESCRIPTION
This PR adds numerous fixes and features to CMake project.

* Removed feature summary (that was bad idea since it cannot show correctly enabled/disabled options)
* Fluidsynth-lite and GLEW now statically compiles into executable.
* Fluidsynth-lite is now bundable into source code via FetchContent, cmake version requirement updated to 3.11 due this.
* Added optional flag to enable/disable console output on MinGW (default is ON).
* Updated travis and appveyor CI pipelines to reflect that.
* Updated documentation.