### PR TITLE
Fix rendering black color as transparent

### DIFF
--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -342,11 +342,14 @@ void SetSDLPalette(int index, int count, uchar *pal)
 
 void SDLDraw()
 {
-	sdlPalette->colors[255].a = 0x00;
+    if (should_opengl_swap()) {
+        sdlPalette->colors[255].a = 0x00;
+    }
+
 	SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, drawSurface);
-	sdlPalette->colors[255].a = 0xff;
 
 	if (should_opengl_swap()) {
+        sdlPalette->colors[255].a = 0xff;
 		SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
 	}
 


### PR DESCRIPTION
Hello. I get black color rendered as transparent. This patch should fix it for both renderers (Software and OpenGL). I don't really understand how rendering is working in System Shock and this patch is made during some experiments with palette, but seems to work.

Before:
![20200417_08h28m31s_grim](https://user-images.githubusercontent.com/812069/79535761-0b7e7a80-8087-11ea-98b8-841c6e1d2f58.png)
![20200417_08h28m27s_grim](https://user-images.githubusercontent.com/812069/79535767-10432e80-8087-11ea-874b-41be50281932.png)

After:
![20200417_08h50m55s_grim](https://user-images.githubusercontent.com/812069/79536366-9318b900-8088-11ea-8caf-fdca88a44aa5.png)
![20200417_08h50m50s_grim](https://user-images.githubusercontent.com/812069/79536374-96ac4000-8088-11ea-9432-7c61f33d8ba2.png)
