### PR TITLE
Don't declare variables in headers included in multiple files.

### DIFF
--- a/src/GameSrc/Headers/mouselook.h
+++ b/src/GameSrc/Headers/mouselook.h
@@ -11,4 +11,4 @@ void mouse_look_unpause();
 
 // Globals
 
-int mlook_vel_x, mlook_vel_y;
+extern int mlook_vel_x, mlook_vel_y;

--- a/src/GameSrc/Headers/musicai.h
+++ b/src/GameSrc/Headers/musicai.h
@@ -156,8 +156,6 @@ int mlimbs_boredom;
 int *output_table;
 uchar wait_flag;
 int next_mode, ai_cycle;
-uchar music_card = TRUE, music_on = FALSE;
-// KLC no sfx_card, sfx_on moved to DIGIFX.C     uchar sfx_card=FALSE, sfx_on=FALSE;
 int cur_digi_channels = 4;
 #else
 extern int mlimbs_peril, mlimbs_positive, mlimbs_motion, mlimbs_monster;

--- a/src/GameSrc/gamestrn.c
+++ b/src/GameSrc/gamestrn.c
@@ -53,7 +53,7 @@ int string_res_file; // string res filenum
 // ---------
 
 uchar *language_files[] = {"res/data/cybstrng.res", "res/data/frnstrng.res", "res/data/gerstrng.res"};
-char which_lang;
+extern char which_lang;
 
 // Wrapper around RefGet suitable for use by lg_sprintf to get string resources
 // for the custom '%S' format specifier.

--- a/src/GameSrc/mouselook.c
+++ b/src/GameSrc/mouselook.c
@@ -13,6 +13,8 @@
 float mlook_hsens = 250;
 float mlook_vsens = 50;
 
+int mlook_vel_x, mlook_vel_y;
+
 extern void pump_events();
 extern void player_set_eye_fixang(int ang);
 extern void physics_set_relax(int axis, uchar relax);

--- a/src/GameSrc/musicai.c
+++ b/src/GameSrc/musicai.c
@@ -64,6 +64,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern void grind_music_ai();
 
+uchar music_card = TRUE, music_on = FALSE;
+
 uchar track_table[NUM_SCORES][SUPERCHUNKS_PER_SCORE];
 uchar transition_table[NUM_TRANSITIONS];
 uchar layering_table[NUM_LAYERS][MAX_KEYS];
@@ -388,7 +390,7 @@ int gen_monster(int monster_num) {
 
 int ext_rp = -1;
 
-extern mlimbs_request_info default_request;
+extern struct mlimbs_request_info default_request;
 
 errtype make_request(int chunk_num, int piece_ID) {
     current_request[chunk_num] = default_request;

--- a/src/GameSrc/wrapper.c
+++ b/src/GameSrc/wrapper.c
@@ -110,7 +110,6 @@ int wrap_id = -1, wrapper_wid, wrap_key_id;
 uchar clear_panel = TRUE, wrapper_panel_on = FALSE;
 grs_font *opt_font;
 uchar olh_temp;
-uchar sfx_on;
 static bool digi_gain = true; // enable sfx volume slider
 errtype (*wrapper_cb)(int num_clicked);
 errtype (*slot_callback)(int num_clicked);

--- a/src/Libraries/2D/Source/tlucdat.h
+++ b/src/Libraries/2D/Source/tlucdat.h
@@ -42,9 +42,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef __SPNDAT
 #define __SPNDAT
 
-uchar *tluc8tab[256];
-uchar *tluc8ltab[256];
-uchar *tluc8stab;
-int tluc8nstab;
+extern uchar *tluc8tab[256];
+extern uchar *tluc8ltab[256];
+extern uchar *tluc8stab;
+extern int tluc8nstab;
 
 #endif

--- a/src/MacSrc/MacTune.c
+++ b/src/MacSrc/MacTune.c
@@ -37,12 +37,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 uchar		mlimbs_on = FALSE;
 char		mlimbs_status = 0;
 
-mlimbs_request_info current_request[MLIMBS_MAX_SEQUENCES - 1]; // Request information
-
-//ulong		mlimbs_counter = 0;
-long		mlimbs_error;
-//uchar		mlimbs_semaphore = FALSE;
-
 // Handle			gHeaderHdl, gTuneHdl, gOfsHdl;			// Holds the tune-related data for the current theme file.
 long			*gOffsets;										// Array of offsets for the beginning of each tune.
 //TunePlayer	gPlayer;										// The Tune Player.

--- a/src/MacSrc/MacTune.h
+++ b/src/MacSrc/MacTune.h
@@ -43,21 +43,11 @@ typedef struct {
 #define MLIMBS_MAX_SEQUENCES 8
 #define MLIMBS_MAX_CHANNELS 8
 
+#include "mlimbs.h"
+
 //-----------------
 //  EXTERN GLOBALS
 //-----------------
-extern uchar mlimbs_on;
-extern char mlimbs_status;
-
-extern mlimbs_request_info current_request[MLIMBS_MAX_SEQUENCES - 1]; // Request information
-
-extern ulong mlimbs_counter;
-extern long mlimbs_error;
-extern uchar mlimbs_semaphore;
-
-extern long *gOffsets; // Array of offsets for the beginning of each tune.
-// extern TunePlayer	gPlayer; // The Tune Player.
-extern bool gTuneDone;     // True when a sequence has finished playing (set by CB proc).
 extern bool gReadyToQueue; // True when it's time to queue up a new sequence.
 
 // extern TuneCallBackUPP	gTuneCBProc;						// The tune's callback proc.

--- a/src/MacSrc/Modding.c
+++ b/src/MacSrc/Modding.c
@@ -5,6 +5,10 @@
 #include <stdio.h>
 #include <dirent.h>
 
+char* modding_archive_override;
+char* modding_additional_files[MAX_MOD_FILES];
+int num_mod_files;
+
 int StringEndsWith( char *src, char *dst) {
 	char* s = strrchr(src, '.');
 

--- a/src/MacSrc/Modding.h
+++ b/src/MacSrc/Modding.h
@@ -13,12 +13,12 @@
 //--------------------
 
 // Let people override the default game archive
-char* modding_archive_override;
+extern char* modding_archive_override;
 
 // Additional resource files to load
-char* modding_additional_files[MAX_MOD_FILES];
+extern char* modding_additional_files[MAX_MOD_FILES];
 
-int num_mod_files;
+extern int num_mod_files;
 
 //--------------------
 //  Function Prototypes

--- a/src/MacSrc/Xmi.c
+++ b/src/MacSrc/Xmi.c
@@ -4,6 +4,21 @@
 #include "MusicDevice.h"
 #include "Prefs.h"
 
+unsigned int NumTracks;
+char ChannelThread[16]; //16 device channels
+int NumUsedChannels; //number of in-use device channels
+
+MIDI_EVENT **TrackEvents;
+short *TrackTiming;
+unsigned short *TrackUsedChannels;
+
+MIDI_EVENT *ThreadEventList[NUM_THREADS];
+int ThreadTiming[NUM_THREADS];
+char ThreadChannelRemap[16*NUM_THREADS];
+SDL_atomic_t DeviceChannelVolume[16]; //only msb: 0-127
+SDL_atomic_t ThreadPlaying[NUM_THREADS];
+SDL_atomic_t ThreadCommand[NUM_THREADS];
+
 MusicDevice *MusicDev;
 static SDL_mutex *MyMutex;
 

--- a/src/MacSrc/Xmi.h
+++ b/src/MacSrc/Xmi.h
@@ -6,12 +6,12 @@
 #define THREAD_STOPTRACK  3
 #define THREAD_EXIT       4
 
-unsigned int NumTracks;
+extern unsigned int NumTracks;
 
 //-1: no thread is using this device channel;  0- : thread index that is using this device channel
-char ChannelThread[16]; //16 device channels
+extern char ChannelThread[16]; //16 device channels
 
-int NumUsedChannels; //number of in-use device channels
+extern int NumUsedChannels; //number of in-use device channels
 
 void FreeXMI(void);
 int ReadXMI(const char *filename);
@@ -39,16 +39,16 @@ struct midi_event_struct
 
 typedef struct midi_event_struct  MIDI_EVENT;
 
-MIDI_EVENT **TrackEvents;
-short *TrackTiming;
-unsigned short *TrackUsedChannels;
+extern MIDI_EVENT **TrackEvents;
+extern short *TrackTiming;
+extern unsigned short *TrackUsedChannels;
 
-MIDI_EVENT *ThreadEventList[NUM_THREADS];
-int ThreadTiming[NUM_THREADS];
-char ThreadChannelRemap[16*NUM_THREADS];
-SDL_atomic_t DeviceChannelVolume[16]; //only msb: 0-127
-SDL_atomic_t ThreadPlaying[NUM_THREADS];
-SDL_atomic_t ThreadCommand[NUM_THREADS];
+extern MIDI_EVENT *ThreadEventList[NUM_THREADS];
+extern int ThreadTiming[NUM_THREADS];
+extern char ThreadChannelRemap[16*NUM_THREADS];
+extern SDL_atomic_t DeviceChannelVolume[16]; //only msb: 0-127
+extern SDL_atomic_t ThreadPlaying[NUM_THREADS];
+extern SDL_atomic_t ThreadCommand[NUM_THREADS];
 
 struct thread_data
 {


### PR DESCRIPTION
Fixes compiling and linking with gcc10 on Fedora 32.

(Declare them as externs, and properly declare/instantiate them in C files instead.  Where it's defined in more than one C file, I commented the others out..)