### PR TITLE
Fix conflict with libevent.

### DIFF
--- a/CMakeLists.32bit.txt
+++ b/CMakeLists.32bit.txt
@@ -274,6 +274,7 @@ set(GAME_SRC
 )
 
 include_directories(
+	BEFORE
 	src/Libraries/2D/Source
 	src/Libraries/3D/Source
 	src/Libraries/AFILE/Source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ set(GAME_SRC
 )
 
 include_directories(
+	BEFORE
 	src/Libraries/2D/Source
 	src/Libraries/3D/Source
 	src/Libraries/AFILE/Source


### PR DESCRIPTION
When libevent is installed its event.h is included instead of
Library/UI's. Fix this situation by including local headers before
the headers in the system.