### PR TITLE
Fix fluidsynth url

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,19 +23,19 @@ cache:
 # Set up environment variable values for 32 and 64 bit builds
 
 for:
--
-  matrix:
-    only:
-      - platform: x86
+  -
+    matrix:
+      only:
+        - platform: x86
     before_build:
       - set BUILD_SCRIPT=build_win32.sh
       - set ARTIFACT=systemshock-x86.zip
       - set MINGW_PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
       - copy CMakeLists.32bit.txt CMakeLists.txt
--
-  matrix:
-    only:
-      - platform: x64
+  -
+    matrix:
+      only:
+        - platform: x64
     before_build:
       - set BUILD_SCRIPT=build_win64.sh
       - set ARTIFACT=systemshock-x64.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,6 @@ for:
       - set BUILD_SCRIPT=build_win64.sh
       - set ARTIFACT=systemshock-x64.zip
       - set MINGW_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\
-
    
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
@@ -56,6 +55,7 @@ build_script:
   - set CMAKE_MAKE_PROGRAM=c:\git\usr\bin\make.exe
   - sh %BUILD_SCRIPT%
   - build.bat
+
 
 # For now, we don't have any automatic tests to run
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,8 @@ build_script:
   - sh %BUILD_SCRIPT%
   - build.bat
 
+# Explicitly tell AppVeyor we're not building a Visual Studio project
+build: off  
    
 # For now, we don't have any automatic tests to run
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,25 +23,23 @@ cache:
 # Set up environment variable values for 32 and 64 bit builds
 
 for:
-  -
-    matrix:
-      only:
-        - platform: x86
+-
+  matrix:
+    only:
+      - platform: x86
     before_build:
       - set BUILD_SCRIPT=build_win32.sh
       - set ARTIFACT=systemshock-x86.zip
       - set MINGW_PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
       - copy CMakeLists.32bit.txt CMakeLists.txt
-    build: off
-  -
-    matrix:
-      only:
-        - platform: x64
+-
+  matrix:
+    only:
+      - platform: x64
     before_build:
       - set BUILD_SCRIPT=build_win64.sh
       - set ARTIFACT=systemshock-x64.zip
       - set MINGW_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\
-    build: off
 
    
 # Actual build script..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ for:
       - set ARTIFACT=systemshock-x86.zip
       - set MINGW_PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\
       - copy CMakeLists.32bit.txt CMakeLists.txt
+    build: off
   -
     matrix:
       only:
@@ -40,6 +41,8 @@ for:
       - set BUILD_SCRIPT=build_win64.sh
       - set ARTIFACT=systemshock-x64.zip
       - set MINGW_PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\
+    build: off
+
    
 # Actual build script..
 # Step 1: Git has to reside in a path without spaces because the SDL build script is weird like that.
@@ -56,9 +59,6 @@ build_script:
   - sh %BUILD_SCRIPT%
   - build.bat
 
-# Explicitly tell AppVeyor we're not building a Visual Studio project
-build: off  
-   
 # For now, we don't have any automatic tests to run
 test: off
 

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -45,7 +45,7 @@ function build_sdl_mixer {
 }
 
 function build_fluidsynth {
-	git clone https://github.com/Doom64/fluidsynth-lite.git
+	git clone https://github.com/EtherTyper/fluidsynth-lite.git
 	pushd fluidsynth-lite
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it

--- a/build_win32.sh
+++ b/build_win32.sh
@@ -51,7 +51,7 @@ function build_glew {
 }
 
 function build_fluidsynth {
-	git clone https://github.com/Doom64/fluidsynth-lite.git
+	git clone https://github.com/EtherTyper/fluidsynth-lite.git
 	pushd fluidsynth-lite
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it

--- a/build_win64.sh
+++ b/build_win64.sh
@@ -33,7 +33,7 @@ function build_glew {
 }
 
 function build_fluidsynth {
-	git clone https://github.com/Doom64/fluidsynth-lite.git
+	git clone https://github.com/EtherTyper/fluidsynth-lite.git
 	pushd fluidsynth-lite
 	sed -i 's/DLL"\ off/DLL"\ on/' CMakeLists.txt
 	# if building fluidsynth fails, move on without it

--- a/osx-linux/install_32bit_sdl.sh
+++ b/osx-linux/install_32bit_sdl.sh
@@ -33,7 +33,7 @@ function build_sdl_mixer {
 }
 
 function build_fluidsynth {
-	git clone https://github.com/Doom64/fluidsynth-lite.git
+	git clone https://github.com/EtherTyper/fluidsynth-lite.git
 	pushd fluidsynth-lite
 
 	# force compilation of dynamic library

--- a/osx-linux/install_64bit_sdl.sh
+++ b/osx-linux/install_64bit_sdl.sh
@@ -33,7 +33,7 @@ function build_sdl_mixer {
 }
 
 function build_fluidsynth {
-	git clone https://github.com/Doom64/fluidsynth-lite.git
+	git clone https://github.com/EtherTyper/fluidsynth-lite.git
 	pushd fluidsynth-lite
 
 	# force compilation of dynamic library


### PR DESCRIPTION
This changes the dead github link of fluidsynth-lite to one maintained by EtherTyper. 