### PR TITLE
Add native MIDI support for Mac OSX via Core MIDI API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,15 +104,22 @@ include_directories(
 )
 
 if(NOT WIN32)
-  # Find ALSA for Linux native MIDI
-  # NOTE: this seems to require having 64-bit dev pacakges installed when building
-  #  on 64-bit OS, even when building a 32-bit binary
-  find_package(ALSA)
-  if(ALSA_FOUND)
-      message(STATUS "ALSA found")
-      include_directories(${ALSA_INCLUDE_DIRS})
-      add_definitions(-DUSE_ALSA=1)
-  endif(ALSA_FOUND)
+	# Find Core MIDI library for Mac native MIDI
+	if(APPLE)
+		find_library(COREFOUNDATION_LIB CoreFoundation REQUIRED)
+		find_library(COREMIDI_LIB       CoreMIDI       REQUIRED)
+		set(COREMIDI_LIBRARIES "${COREFOUNDATION_LIB};${COREMIDI_LIB}")
+		message(STATUS "COREMIDI_LIBRARIES=${COREMIDI_LIBRARIES}")
+	endif(APPLE)
+	# Find ALSA for Linux native MIDI
+	# NOTE: this seems to require having 64-bit dev pacakges installed when building
+	#  on 64-bit OS, even when building a 32-bit binary
+	find_package(ALSA)
+	if(ALSA_FOUND)
+		message(STATUS "ALSA found")
+		include_directories(${ALSA_INCLUDE_DIRS})
+		add_definitions(-DUSE_ALSA=1)
+	endif(ALSA_FOUND)
 endif(NOT WIN32)
 
 # Generate version based on project version
@@ -415,6 +422,7 @@ target_link_libraries(systemshock
 	${SDL2_MIXER_LIBRARIES}
 	${FLUIDSYNTH_LIBRARIES}
 	${OPENGL_LIBRARIES}
+	${COREMIDI_LIBRARIES}
 	${ALSA_LIBRARIES}
 )
 


### PR DESCRIPTION
A couple of years ago I contributed native MIDI support for Windows and Linux, but was not able to do so for Mac OSX because I lacked a workable development environment. This has been remedied, and I was able to implement and test Core MIDI support in an OSX Mojave VM talking to a real Roland SC-88 via a USB-MIDI interface.

As with Windows, support for this is automatically enabled in OSX builds because it's an OS-provided functionality.

File change notes:
- CMakeLists.txt:
  - link required Core API libraries on OSX
- src/MusicSrc/MusicDevice.c:
  - include relevant headers for native MIDI support on OSX
  - add Core MIDI handles to native MIDI device struct on OSX
  - change Windows NativeMidiSendMessage() to take a pointer for outHandle so that calling code can stay common between that and OSX
  - add device name lookup utilities from rtmidi library
  - implement Core MIDI based NativeMidiSendMessage() function
  - implement Core MIDI device init/destroy and device query logic
  - update NativeMidiSendMessage() callers to pass outHandle as pointer for Windows and OSX