### PR TITLE
explicit MFD selection

### DIFF
--- a/src/GameSrc/Headers/mfdext.h
+++ b/src/GameSrc/Headers/mfdext.h
@@ -54,6 +54,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MFD_LEFT  0
 #define MFD_RIGHT 1
 
+#define ENCODE_MFD_SELECTION(side, no) ((side) * 100 + (no))
+#define DECODE_MFD_SELECTION(side, no, code) do { no = (code) % 100; side = (code) / 100; } while(0)
+
 // Flags for MFD Functions
 #define MFD_CHANGEBIT      0x01 // Needs constant update of some sort
 #define MFD_INCREMENTAL    0x02 // Uses standard MFD background

--- a/src/GameSrc/newmfd.c
+++ b/src/GameSrc/newmfd.c
@@ -959,22 +959,12 @@ uchar mfd_button_callback(uiEvent *e, LGRegion *r, intptr_t udata) {
 
 uchar mfd_button_callback_kb(ushort keycode, uint32_t context, intptr_t data) {
     int which_panel, which_button;
-    int fkeynum;
 
     if (!global_fullmap->cyber) {
 
-        fkeynum = (int)keycode - 128;
+        DECODE_MFD_SELECTION(which_panel, which_button, data);
 
-        if (fkeynum >= MFD_NUM_VIRTUAL_SLOTS) {
-            which_panel = MFD_RIGHT;
-        }
-        else {
-            which_panel = MFD_LEFT;
-        }
-
-        which_button = ((int)fkeynum) % MFD_NUM_VIRTUAL_SLOTS;
-
-        mfd_select_button(which_panel, which_button);
+        mfd_select_button(which_panel, which_button % MFD_NUM_VIRTUAL_SLOTS);
     }
 
     return TRUE;

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -37,6 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "input.h"
 #include "mainloop.h"
 #include "movekeys.h"
+#include "mfdext.h"
 
 extern uchar mfd_button_callback_kb(ushort keycode, uint32_t context, intptr_t data);
 extern uchar hw_hotkey_callback(ushort keycode, uint32_t context, intptr_t data);
@@ -561,16 +562,16 @@ HOTKEYLOOKUP HotKeyLookup[] = {
     {"\"data reader\"", DEMO_CONTEXT, hw_hotkey_callback, 8, 0, 56, 0},
     {"\"booster\"", DEMO_CONTEXT, hw_hotkey_callback, 12, 0, 57, 0},
     {"\"jumpjets\"", DEMO_CONTEXT, hw_hotkey_callback, 13, 0, 48, 0},
-    {"\"mfd left 1\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F1, 0},
-    {"\"mfd left 2\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F2, 0},
-    {"\"mfd left 3\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F3, 0},
-    {"\"mfd left 4\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F4, 0},
-    {"\"mfd left 5\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F5, 0},
-    {"\"mfd right 1\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F6, 0},
-    {"\"mfd right 2\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F7, 0},
-    {"\"mfd right 3\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F8, 0},
-    {"\"mfd right 4\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F9, 0},
-    {"\"mfd right 5\"", DEMO_CONTEXT, mfd_button_callback_kb, 0, 0, KEY_F10, 0},
+    {"\"mfd left 1\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_LEFT, MFD_WEAPON_SLOT), 0, KEY_F1, 0},
+    {"\"mfd left 2\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_LEFT, MFD_ITEM_SLOT), 0, KEY_F2, 0},
+    {"\"mfd left 3\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_LEFT, MFD_MAP_SLOT), 0, KEY_F3, 0},
+    {"\"mfd left 4\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_LEFT, MFD_TARGET_SLOT), 0, KEY_F4, 0},
+    {"\"mfd left 5\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_LEFT, MFD_INFO_SLOT), 0, KEY_F5, 0},
+    {"\"mfd right 1\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_RIGHT, MFD_WEAPON_SLOT), 0, KEY_F6, 0},
+    {"\"mfd right 2\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_RIGHT, MFD_ITEM_SLOT), 0, KEY_F7, 0},
+    {"\"mfd right 3\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_RIGHT, MFD_MAP_SLOT), 0, KEY_F8, 0},
+    {"\"mfd right 4\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_RIGHT, MFD_TARGET_SLOT), 0, KEY_F9, 0},
+    {"\"mfd right 5\"", DEMO_CONTEXT, mfd_button_callback_kb, ENCODE_MFD_SELECTION(MFD_RIGHT, MFD_INFO_SLOT), 0, KEY_F10, 0},
     {"\"keypad 0\"", DEMO_CONTEXT, keypad_hotkey_func, 0, 0, DOWN('0'), 0},
     {"\"keypad 1\"", DEMO_CONTEXT, keypad_hotkey_func, 0, 0, DOWN('1'), 0},
     {"\"keypad 2\"", DEMO_CONTEXT, keypad_hotkey_func, 0, 0, DOWN('2'), 0},


### PR DESCRIPTION
On Ubuntu 20.04 and system SDL I have an issue. MFD selection do not work for left MFD. All F1..F10 keys are changing the MFD-panel on the right.
It happens because keycodes for F1..F10 much larger than 128 and interpreted as keys for right-side MFD.

Explicit selection of MFD sides and buttons is fixing this issue.

(Personally I don't use F1..F10. But I going to change game controls code so I started with this)