### PR TITLE
Supporting native arm builds on OSX by updating SDL to 2.26.0

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-SDL_version=2.0.9
-SDL2_mixer_version=2.0.4
+SDL_version=2.26.0
+SDL2_mixer_version=2.6.3
 
 if [ -d ./build_ext/ ]; then
 	echo A directory named build_ext already exists.

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <3d.h>
+#include <SDL.h>
 
 #ifdef USE_OPENGL
 
@@ -18,7 +19,7 @@ bool use_opengl();
 void toggle_opengl();
 void opengl_resize(int width, int height);
 bool should_opengl_swap();
-void opengl_swap_and_restore();
+void opengl_swap_and_restore(SDL_Surface *ui);
 void opengl_change_palette();
 
 void opengl_set_viewport(int x, int y, int width, int height);
@@ -46,7 +47,7 @@ static bool use_opengl() { return false; }
 static void toggle_opengl() {}
 static void opengl_resize(int width, int height) {}
 static bool should_opengl_swap() { return false; }
-static void opengl_swap_and_restore() {}
+static void opengl_swap_and_restore(SDL_Surface *ui) {}
 static void opengl_change_palette() {}
 
 static void opengl_set_viewport(int x, int y, int width, int height) {}

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -194,6 +194,7 @@ void InitSDL() {
     char window_title[128];
     sprintf(window_title, "System Shock - %s", SHOCKOLATE_VERSION);
 
+    SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
     window = SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, grd_cap->w, grd_cap->h,
                               SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_OPENGL);
 
@@ -232,7 +233,7 @@ void SetSDLPalette(int index, int count, uchar *pal) {
     static bool gammalut_init = 0;
     static uchar gammalut[100 - 10 + 1][256];
     if (!gammalut_init) {
-        double factor = (can_use_opengl() ? 1.0 : 2.2); // OpenGL uses 2.2
+        double factor = (use_opengl() ? 1.0 : 2.2); // OpenGL uses 2.2
         int i, j;
         for (i = 10; i <= 100; i++) {
             double gamma = (double)i * 1.0 / 100;
@@ -279,26 +280,28 @@ void SetSDLPalette(int index, int count, uchar *pal) {
 
 void SDLDraw() {
     if (should_opengl_swap()) {
+        // We want the UI background to be transparent!
         sdlPalette->colors[255].a = 0x00;
-    }
 
-    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, drawSurface);
-
-    if (should_opengl_swap()) {
+        // Draw the OpenGL view
+        opengl_swap_and_restore(drawSurface);
+        
+        // Set the palette back, and we are done
         sdlPalette->colors[255].a = 0xff;
-        SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+        return;
     }
 
+    // Clear the screen!
+    SDL_RenderClear(renderer);
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, drawSurface);
+    
+    // Blit to the screen by drawing the surface 
     SDL_Rect srcRect = {0, 0, gScreenWide, gScreenHigh};
     SDL_RenderCopy(renderer, texture, &srcRect, NULL);
     SDL_DestroyTexture(texture);
 
-    if (should_opengl_swap()) {
-        opengl_swap_and_restore();
-    } else {
-        SDL_RenderPresent(renderer);
-        SDL_RenderClear(renderer);
-    }
+    // Show everything we've drawn
+    SDL_RenderPresent(renderer);
 }
 
 bool MouseCaptured = FALSE;


### PR DESCRIPTION
* Upgrades SDL to 2.26.0, and SDL Mixer to 2.6.3
* Fixes OpenGL rendering on OSX, can no longer abuse context switching
* Also fixes the gamma being way too dark when OpenGL is supported