### PR TITLE
Mouselook stance freeze fix

### DIFF
--- a/src/GameSrc/mouselook.c
+++ b/src/GameSrc/mouselook.c
@@ -71,19 +71,7 @@ void mouse_look_physics() {
         }
 
         if (mvelx != 0) {
-            Obj *cobj = &objs[PLAYER_OBJ];
-
-            // Turning the player is harder, need to update the physics state
-
-            // Grab physics state
-            State current_state;
-            EDMS_get_state(objs[PLAYER_OBJ].info.ph, &current_state);
-
-            // Turn us a bit
-            current_state.alpha += mvelx;
-
-            // Now put the player there
-            EDMS_holistic_teleport(objs[PLAYER_OBJ].info.ph, &current_state);
+            EDMS_mouselook(objs[PLAYER_OBJ].info.ph, mvelx);
         }
     }
 }

--- a/src/Libraries/EDMS/Source/edms.h
+++ b/src/Libraries/EDMS/Source/edms.h
@@ -149,6 +149,7 @@ void EDMS_get_state(physics_handle ph, State *s);
 void EDMS_startup(EDMS_data *D);
 void EDMS_kill_object(physics_handle ph);
 void EDMS_holistic_teleport(physics_handle ph, State *s);
+void EDMS_mouselook(physics_handle ph, int32_t xlook);
 
 //	Object packages...
 //	==================

--- a/src/Libraries/EDMS/Source/interfac.cc
+++ b/src/Libraries/EDMS/Source/interfac.cc
@@ -308,6 +308,17 @@ void EDMS_holistic_teleport(physics_handle ph, State *s) {
     }
 }
 
+void EDMS_mouselook(physics_handle ph, int32_t xlook) {
+    int32_t on;
+    State current_state;
+
+    on = physics_handle_to_object_number(ph);
+    EDMS_get_state(ph, &current_state);
+
+    S[on][3][0].fix_to(current_state.alpha + xlook);
+    S[on][3][1] = fix_zero;
+}
+
 //	Here we exclude objects from hitting each specific others...
 //	============================================================
 void EDMS_ignore_collisions(physics_handle ph1, physics_handle ph2) {


### PR DESCRIPTION
Just a re-implementation of horizontal mouse look that no longer freezes up the player's stance (leaning, crouching, etc.) while looking around.