### PR TITLE
Editingkeys as hotkeys (#1)

### DIFF
--- a/src/GameSrc/input.c
+++ b/src/GameSrc/input.c
@@ -2278,9 +2278,12 @@ uchar view3d_mouse_handler(uiEvent *ev, LGRegion *r, intptr_t v) {
        }
 
     */
-    if ((md->buttons & (1 << MOUSE_RBUTTON)) == 0 ||
-        ((md->buttons & (1 << MOUSE_RBUTTON)) == 0 && global_fullmap->cyber))
+    if ((md->buttons & (1 << MOUSE_CBUTTON)) == 0)
         physics_set_one_control(MOUSE_CONTROL_BANK, CONTROL_ZVEL, 0);
+
+    if ((md->buttons & (1 << MOUSE_CBUTTON)) && !global_fullmap->cyber)
+        physics_set_one_control(MOUSE_CONTROL_BANK, CONTROL_ZVEL,
+                                MAX_JUMP_CONTROL);
 
     if (md->action & UI_MOUSE_LDOUBLE) {
         // Spew(DSRC_USER_I_Motion,("use this, bay-bee!\n"));

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -689,8 +689,10 @@ void pump_events(void) {
                 mouseEvent.buttons |= down ? (1 << MOUSE_RBUTTON) : 0;
                 break;
 
-                // case SDL_BUTTON_MIDDLE: // TODO: is this MOUSE_CDOWN/UP ?
-                // break;
+            case SDL_BUTTON_MIDDLE:
+                mouseEvent.type = down ? MOUSE_CDOWN : MOUSE_CUP;
+                mouseEvent.buttons |= down ? (1 << MOUSE_CBUTTON) : 0;
+                break;
             }
 
             if (mouseEvent.type != 0) {

--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -189,7 +189,7 @@ static uchar sdlKeyCodeToSSHOCKkeyCode(SDL_Keycode kc) {
         return 0x2F; //  kVK_ANSI_Period = 0x2F,
     case SDLK_BACKQUOTE:
         return 0x32; //  kVK_ANSI_Grave = 0x32, // TODO: really?
-    case SDLK_KP_DECIMAL:
+    case SDLK_KP_PERIOD:
         return 0x41; //  kVK_ANSI_KeypadDecimal   = 0x41,
     case SDLK_KP_MULTIPLY:
         return 0x43; //  kVK_ANSI_KeypadMultiply = 0x43,
@@ -299,7 +299,8 @@ static uchar sdlKeyCodeToSSHOCKkeyCode(SDL_Keycode kc) {
         return 0x73; //  kVK_Home = 0x73,
     case SDLK_PAGEUP:
         return 0x74; //  kVK_PageUp = 0x74,
-    // case SDLK_ : return 0x75; //  kVK_ForwardDelete = 0x75, // TODO: what's this?
+    case SDLK_INSERT:
+        return 0x75; //  kVK_ForwardDelete = 0x75, // TODO: what's this?
     case SDLK_F4:
         return 0x76; //  kVK_F4 = 0x76,
     case SDLK_END:
@@ -561,11 +562,26 @@ void pump_events(void) {
                     case SDLK_KP_ENTER:
                         keyEvent.ascii = 128 + 16;
                         break;
-                    case SDLK_KP_DECIMAL:
+                    case SDLK_KP_PERIOD:
                         keyEvent.ascii = 128 + 17;
                         break;
                     case SDLK_KP_0:
                         keyEvent.ascii = 128 + 18;
+                        break;
+                    case SDLK_HOME:
+                        keyEvent.ascii = 128 + 19;
+                        break;
+                    case SDLK_PAGEUP:
+                        keyEvent.ascii = 128 + 20;
+                        break;
+                    case SDLK_INSERT:
+                        keyEvent.ascii = 128 + 21;
+                        break;
+                    case SDLK_END:
+                        keyEvent.ascii = 128 + 23;
+                        break;
+                    case SDLK_PAGEDOWN:
+                        keyEvent.ascii = 128 + 25;
                         break;
                     }
                 }

--- a/src/MacSrc/Prefs.c
+++ b/src/MacSrc/Prefs.c
@@ -433,10 +433,11 @@ static struct {
                       {"keypad_minus ", 128 + 14, 0x4E},
                       {"keypad_plus ", 128 + 15, 0x45},
                       {"keypad_enter ", 128 + 16, 0x4C},
-                      {"keypad_decimal ", 128 + 17, 0x41},
+                      {"keypad_period ", 128 + 17, 0x41},
                       {"keypad_0 ", 128 + 18, 0x52},
 
                       // these have no invented "ascii" codes so they can't be used as hotkeys, only move keys
+                      // except the six editing keys should be allowed as hotkeys
                       {"keypad_home ", 0, 0x59},
                       {"keypad_up ", 0, 0x5B},
                       {"keypad_pgup ", 0, 0x5C},
@@ -446,9 +447,12 @@ static struct {
                       {"keypad_end ", 0, 0x53},
                       {"keypad_down ", 0, 0x54},
                       {"keypad_pgdn ", 0, 0x55},
-                      {"home ", 0, 0x73},
+                      {"home ", 128 + 19, 0x73},
                       {"up ", 0, 0x7E},
-                      {"pageup ", 0, 0x74},
+                      {"pageup ", 128 + 20, 0x74},
+                      {"insert ", 128 + 21, 0x75},
+                      {"end ", 128 + 23, 0x77},
+                      {"pagedown ", 128 + 25, 0x79},
                       {"left ", 0, 0x7B},
                       {"right ", 0, 0x7C},
                       {"end ", 0, 0x77},


### PR DESCRIPTION
Six editing keys (Ins, Del, Home, End, PgUp, PgDn) should be hotkey-able. Add missing Ins key.
keypad_decimal is not decimal point key (it's decimal number base 10 key), The correct name is keypad_period.

* Update sdl_events.c
* Update Prefs.c
